### PR TITLE
check vote against all accounts

### DIFF
--- a/sbi_upvote_post_comment.py
+++ b/sbi_upvote_post_comment.py
@@ -233,7 +233,8 @@ def run():
                 vote_time = None
                 while not vote_sucessfull and cnt < 5:
                     try:
-                        if not Account(voter).has_voted(c):
+                        if all(v not in accounts for v in c["active_votes"]):
+                        #if not Account(voter).has_voted(c):
                             c.upvote(vote_percentage, voter=voter)
                             time.sleep(6)
                             c.refresh()
@@ -305,7 +306,8 @@ def run():
                         vote_time = None
                         while not vote_sucessfull and cnt < 5:
                             try:
-                                if not Account(voter).has_voted(c):
+                                if all(v not in accounts for v in c["active_votes"]):
+                                #if not Account(voter).has_voted(c):
                                     c.upvote(vote_percentage, voter=voter)
                                     time.sleep(6)
                                     c.refresh()
@@ -343,7 +345,8 @@ def run():
                     vote_time = None
                     while not vote_sucessfull and cnt < 5:
                         try:
-                            if not Account(voter).has_voted(c):
+                            if all(v not in accounts for v in c["active_votes"]):
+                            #if not Account(voter).has_voted(c):
                                 c.upvote(vote_percentage, voter=voter)
                                 time.sleep(6)
                                 c.refresh()


### PR DESCRIPTION
This is more of a bandaid but it should only allow the assertion to run it's course once against one account and prevent it from going on to the next one as it checks against all possible voting accounts instead of just if the single voter has voted. Not ideal but should at least prevent the negative balances from getting multiple accounts to vote on a single post.