### PR TITLE
End stop block 1 short of head

### DIFF
--- a/sbi_stream_post_comment.py
+++ b/sbi_stream_post_comment.py
@@ -136,7 +136,7 @@ def run():
     already_voted_posts = []
     flagged_posts = []
     start_block = b.get_current_block_num() - int(28800)
-    stop_block = b.get_current_block_num()
+    stop_block = b.get_current_block_num() - int(1)
     last_block_print = start_block
 
     latest_update = postTrx.get_latest_post()


### PR DESCRIPTION
Don't know why the start uses `int(28800)` to subtract and I followed the same syntax