### PR TITLE
fix: use upsert instead of insert to prevent duplicate virtual operations

### DIFF
--- a/steembi/storage.py
+++ b/steembi/storage.py
@@ -152,7 +152,7 @@ class TrxDB(object):
 
         """
         table = self.db[self.__tablename__]
-        table.insert(data)    
+        table.upsert(data, ['virtual_op', 'block', 'trx_in_block', 'op_in_trx'])    
         self.db.commit()
 
     def delete(self, index, source):


### PR DESCRIPTION
This is the only other place that was using `insert` for transactions instead of `upsert`. I use the same composite key style, so it should go with no issues.