### PR TITLE
[codex] Fix token issuance intent reconciliation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,43 @@
   **deprecated** (no longer on any production path) but retained, with docstrings, for
   ad-hoc reporting / historical recomputation.
 
+## Token issuance: reconciliation hardening (PR #139 review fixes)
+
+- **Contested rows are never failed.** A PENDING row with any in-window chain
+  candidate (tie-skipped, or attributed to a sibling row by timestamp proximity) is
+  left PENDING even when the scan covers its window — that issue may be its own
+  broadcast, so failing it could re-issue tokens already minted. Liveness is
+  preserved: once the sibling SUCCESS row records the chain `trx_id`, the next pass
+  excludes that issue and the contested row resolves normally.
+- **Scan coverage extends to scan time.** `history_reverse` starts at the account
+  head, so a successful fetch proves no ops newer than the newest scanned op exist;
+  `covered_until` is now the scan start minus the clock-skew margin instead of the
+  newest op timestamp. A quiet issuer (no recent on-chain activity) can therefore
+  still resolve stale PENDING rows, and an empty history counts as complete
+  coverage. The scan op budget scales with the lookback (capped at
+  `HISTORY_SCAN_HARD_LIMIT`) so an old stuck PENDING row cannot outgrow the scan.
+- **Unit Conversion is idempotent per source transaction.** Before inserting the
+  intent, the sbi-tokens path checks `source_trx_id` + rationale for an existing
+  PENDING/SUCCESS row (`has_issuance_for_source`; FAILURE still allows retry), so a
+  reprocessed transfer op can no longer double-mint.
+- **Write-ahead helpers moved to `hivesbi/issuance_log.py`**, shared by
+  `hivesbi/parse_hist_op.py` and `hsbi_token_snapshot.py` (which re-exports them);
+  the dead `now` parameter was removed from `reconcile_issuances`.
+- **Management virtual refresh preserves the management account's own delegation
+  grant**: `refresh_management_virtual_tokens` adds the derived 10% on top of any
+  delegation-derived virtual tokens josephsavage earned as an ordinary delegator,
+  instead of overwriting them.
+- Runbook: added a DB time-zone pre-check (`issued_at` is a TIMESTAMP matched
+  against UTC chain timestamps within ±minutes, so the session time zone must be
+  UTC) and a review/cleanup section for legacy `rationale='reconciled'` rows left
+  by PR #138.
+- Tests: fixed the stale-coverage test (coverage must span
+  `issued_at - MATCH_CLOCK_SKEW`) and the equal-distance ambiguity test
+  (second-precision `issued_at` requires whole-second timestamps); added coverage
+  for contested-row protection + next-pass resolution, quiet-issuer/empty-history
+  scan coverage, the source-transaction dedup guard, and Management own-delegation
+  preservation.
+
 ## Token issuance: write-ahead intents + chain reconciliation (PR #138 follow-up)
 
 - All HSBIDAO issuance paths now use a committed write-ahead intent row before

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,32 +21,38 @@
   **deprecated** (no longer on any production path) but retained, with docstrings, for
   ad-hoc reporting / historical recomputation.
 
-## Token issuance: Management 10% + chain reconciliation (PR #138)
+## Token issuance: write-ahead intents + chain reconciliation (PR #138 follow-up)
 
-- `hsbi_token_snapshot.py` now issues the **Management 10%** to `josephsavage` each
-  ~2.4 h snapshot cycle, replacing the prior irregular manual issuance. The cap targets
-  10% of *real* circulating supply (`SUM(tokens − virtual_tokens)`, excluding
-  `sbi-tokens`); `calculate_management_issue_amount` = `(0.10·outstanding − issued) / 0.90`,
-  where `issued` counts SUCCESS **and** PENDING. It is **write-ahead**: a committed
-  PENDING row counts toward the cap before the broadcast, so a crash after broadcast
-  cannot double-mint.
-- Chain-confirm reconciliation (`reconcile_issuances`) resolves Management PENDING rows
-  against the issuer's recent on-chain HSBIDAO issuances: matched → SUCCESS; genuinely
-  absent past the window (only when the scan provably covered the row) → FAILURE so the
-  cap frees up. Reconciliation is **rationale-scoped to Management** and recognises
-  confirmed pik/abc dividends by logged `trx_id` (and, defensively, recipient+units), so
-  a same-amount member dividend to `josephsavage` is never mistaken for a Management
-  issuance.
-- Per-member **pik / abc_pik issuance stays immediate and self-healing** (no write-ahead
-  PENDING guard): a confirmed broadcast zeroes the balance and logs SUCCESS; a failed
-  broadcast logs FAILURE and leaves the balance for retry next cycle. This deliberately
-  avoids a regression where a transient failure could strand a member's dividends behind
-  an unresolved PENDING row (see review finding A). `token_issuance_log.status` gained a
-  `PENDING` enum value for the Management path only.
-- Tests: `tests/test_virtual_tokens.py` covers delegation virtual_tokens + atomicity, the
-  immediate pik/abc success/failure paths, Management cap math + convergence + write-ahead,
-  `sync_tokenholders`, and rationale-scoped reconciliation (incl. that a confirmed pik
-  chain op is never attributed to Management).
+- All HSBIDAO issuance paths now use a committed write-ahead intent row before
+  broadcast: pik, Pending Balance Conversion, Management, and Unit Conversion insert
+  `token_issuance_log.trx_id = 'PENDING'` with durable recipient, units, rationale,
+  optional `source_trx_id`, and an app-written UTC `issued_at` intent timestamp. On a
+  successful broadcast the same row moves to `SUCCESS` with the actual Hive Engine
+  `tokens.issue` transaction id. On broadcast exception the row stays `PENDING` with
+  `error_message`, and member balances are preserved for reconciliation or retry.
+- `token_issuance_log.trx_id` now means the actual Hive Engine `tokens.issue`
+  transaction id. `token_issuance_log.source_trx_id` means the origin transaction id,
+  such as the HBD transfer that triggered Unit Conversion. Unit Conversion stores the
+  source transfer hash in `source_trx_id` and the returned Hive Engine issue hash in
+  `trx_id`; it no longer uses the source transfer hash as the issuance id.
+- Reconciliation (`reconcile_issuances`) only completes, fails, or reports existing
+  rows. It never inserts a new issuance row and never invents `rationale='reconciled'`.
+  Exact `trx_id` matches are already handled; unresolved `PENDING` rows match chain
+  issues by recipient, normalized units, and authoritative blockchain transaction
+  timestamp relative to the stored intent timestamp. Ambiguous equal-distance matches
+  remain unresolved.
+- Reconciliation split timing into chain matching and scan coverage. A PENDING row is
+  marked `FAILURE` only when the chain scan proves it covered the entire possible match
+  range; orphan chain issuances are printed for operator review only.
+- `hsbi_check_delegation.py` now refreshes the derived Management virtual token
+  allocation every pass: `josephsavage.virtual_tokens = ROUND(SUM(non-josephsavage
+  virtual_tokens) * 0.10, 3)`. The Management row is upserted and excluded from the
+  source sum to avoid compounding.
+- Tests: `tests/test_virtual_tokens.py` covers delegation virtual_tokens + atomicity,
+  Management virtual token refresh/upsert, write-ahead issuance success/failure and
+  duplicate-pending guards, Unit Conversion source-vs-issue transaction ids,
+  timestamp-based reconciliation, stale scan coverage, orphan reporting without insert,
+  and the `6fda...` source / `af4...` issue regression.
 
 ## Memo parsing (PR #138)
 

--- a/docker/mariadb/init/01-sbi-schema.sql
+++ b/docker/mariadb/init/01-sbi-schema.sql
@@ -341,9 +341,11 @@ CREATE TABLE `token_issuance_log` (
   `status` enum('SUCCESS','FAILURE','PENDING') NOT NULL,
   `error_message` text DEFAULT NULL,
   `rationale` varchar(100) DEFAULT NULL,
+  `source_trx_id` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_recipient` (`recipient`),
-  KEY `idx_trx_id` (`trx_id`)
+  KEY `idx_trx_id` (`trx_id`),
+  KEY `idx_source_trx_id` (`source_trx_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=159353 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/hivesbi/issuance_log.py
+++ b/hivesbi/issuance_log.py
@@ -1,0 +1,121 @@
+"""Write-ahead issuance log helpers for `token_issuance_log`.
+
+Every HSBIDAO issuance path commits an intent row before broadcasting. The
+broadcast is the only step that cannot be rolled back, so chain reconciliation
+(hsbi_token_snapshot.reconcile_issuances) completes the same row from chain
+history if the process dies before SUCCESS is recorded.
+
+rationale is the durable, never-rewritten reason an issuance happened (pik,
+Pending Balance Conversion, Unit Conversion, Management). It is always written
+by the code that initiates the issuance and is never inferred from the chain.
+"""
+
+from datetime import datetime, timezone
+
+PENDING_TRX_PLACEHOLDER = "PENDING"
+UNCAPTURED_TRX_PLACEHOLDER = "N/A"
+
+
+def utcnow():
+    return datetime.now(timezone.utc)
+
+
+def issue_trx_id(tx):
+    return tx.get("trx_id") or tx.get("transaction_id") or UNCAPTURED_TRX_PLACEHOLDER
+
+
+def insert_pending_issuance(
+    conn, recipient, units, rationale, source_trx_id=None, issued_at=None
+):
+    issued_at = issued_at or utcnow()
+    result = conn.exec_driver_sql(
+        """
+        INSERT INTO token_issuance_log
+            (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id)
+        VALUES (%s, %s, %s, %s, 'PENDING', NULL, %s, %s)
+        """,
+        (PENDING_TRX_PLACEHOLDER, recipient, units, issued_at, rationale, source_trx_id),
+    )
+    return result.lastrowid
+
+
+def mark_issuance_success(conn, log_id, trx_id):
+    conn.exec_driver_sql(
+        """
+        UPDATE token_issuance_log
+        SET status = 'SUCCESS', trx_id = %s, error_message = NULL
+        WHERE id = %s
+        """,
+        (trx_id, log_id),
+    )
+
+
+def complete_uncaptured_success(conn, log_id, trx_id):
+    conn.exec_driver_sql(
+        "UPDATE token_issuance_log SET trx_id = %s, error_message = NULL WHERE id = %s",
+        (trx_id, log_id),
+    )
+
+
+def mark_issuance_failure(conn, log_id, error_message):
+    conn.exec_driver_sql(
+        "UPDATE token_issuance_log SET status = 'FAILURE', error_message = %s WHERE id = %s",
+        (error_message, log_id),
+    )
+
+
+def record_pending_error(conn, log_id, error_message):
+    """Keep a row PENDING (so it still guards against re-issue) but note the error.
+
+    A broadcast that raised may still have reached the chain, so we do not assume
+    failure here — chain reconciliation resolves the row to SUCCESS or FAILURE.
+    """
+    conn.exec_driver_sql(
+        "UPDATE token_issuance_log SET error_message = %s WHERE id = %s",
+        (error_message, log_id),
+    )
+
+
+def has_issuance_for_source(conn, source_trx_id, rationale):
+    """True when the origin transaction already has a live issuance row.
+
+    PENDING (in flight / awaiting reconciliation) and SUCCESS rows both block a
+    re-issue for the same source transaction; a FAILURE row (provably never on
+    chain) does not, so a genuine retry stays possible.
+    """
+    count = conn.exec_driver_sql(
+        """
+        SELECT COUNT(*) FROM token_issuance_log
+        WHERE source_trx_id = %s AND rationale = %s
+          AND status IN ('PENDING', 'SUCCESS')
+        """,
+        (source_trx_id, rationale),
+    ).scalar()
+    return bool(count)
+
+
+def log_issuance(
+    conn,
+    trx_id,
+    recipient,
+    units,
+    status,
+    rationale,
+    error_message=None,
+    source_trx_id=None,
+    issued_at=None,
+):
+    """Append a terminal (SUCCESS/FAILURE) issuance row.
+
+    Retained for legacy tests and historical compatibility; new issuance paths
+    should use insert_pending_issuance followed by mark_issuance_success.
+    """
+    issued_at = issued_at or utcnow()
+    conn.exec_driver_sql(
+        """
+        INSERT INTO token_issuance_log
+            (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id),
+    )

--- a/hivesbi/parse_hist_op.py
+++ b/hivesbi/parse_hist_op.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from nectar.account import Account
 from nectar.amount import Amount
@@ -18,6 +18,52 @@ from hivesbi.memo_parser import MemoParser
 from hivesbi.settings import get_runtime
 
 log = logging.getLogger(__name__)
+
+PENDING_TRX_PLACEHOLDER = "PENDING"
+UNIT_CONVERSION_RATIONALE = "Unit Conversion"
+
+
+def _issue_trx_id(tx):
+    return tx.get("trx_id") or tx.get("transaction_id") or "N/A"
+
+
+def _insert_pending_token_issuance(
+    conn, recipient, units, rationale, source_trx_id=None
+):
+    result = conn.exec_driver_sql(
+        """
+        INSERT INTO token_issuance_log
+            (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id)
+        VALUES (%s, %s, %s, %s, 'PENDING', NULL, %s, %s)
+        """,
+        (
+            PENDING_TRX_PLACEHOLDER,
+            recipient,
+            units,
+            datetime.now(timezone.utc),
+            rationale,
+            source_trx_id,
+        ),
+    )
+    return result.lastrowid
+
+
+def _mark_token_issuance_success(conn, log_id, trx_id):
+    conn.exec_driver_sql(
+        """
+        UPDATE token_issuance_log
+        SET status = 'SUCCESS', trx_id = %s, error_message = NULL
+        WHERE id = %s
+        """,
+        (trx_id, log_id),
+    )
+
+
+def _record_token_issuance_error(conn, log_id, error_message):
+    conn.exec_driver_sql(
+        "UPDATE token_issuance_log SET error_message = %s WHERE id = %s",
+        (error_message, log_id),
+    )
 
 
 class ParseAccountHist(list):
@@ -715,61 +761,54 @@ class ParseAccountHist(list):
                 }
             )
             if db2 is not None:
-                with db2.engine.begin() as conn:
-
-                    # Issue default tokens to the sender if nominee is sbi-tokens
-                    if nominee == "sbi-tokens":
-                        token_recipient = sender
-                        print(
-                            f"[PointTransfer] Issuing default tokens: trx_id={trx_id} recipient={token_recipient} "
-                            f"units={transferable_units}"
+                # Issue default tokens to the sender if nominee is sbi-tokens.
+                if nominee == "sbi-tokens":
+                    token_recipient = sender
+                    with db2.engine.begin() as conn:
+                        log_id = _insert_pending_token_issuance(
+                            conn,
+                            token_recipient,
+                            transferable_units,
+                            UNIT_CONVERSION_RATIONALE,
+                            source_trx_id=trx_id,
                         )
-                        try:
-                            issue_default_tokens(token_recipient, transferable_units)
-                        except Exception as e:
-                            log.exception(
-                                "Failed to issue default tokens for %s (%s units)",
-                                token_recipient,
-                                transferable_units,
-                            )
-                            # Insert failure record into log table
-                            conn.exec_driver_sql(
-                                """
-                                INSERT INTO token_issuance_log (trx_id, recipient, units, status, error_message)
-                                VALUES (%s, %s, %s, %s, %s)
-                                """,
-                                (trx_id, token_recipient, transferable_units, "FAILURE", str(e)),
-                            )
-
-                        else:
-                            log.info("Issued %d HSBI tokens to %s", transferable_units, sender)
-                            # Insert success record into log table
-                            conn.exec_driver_sql(
-                                """
-                                INSERT INTO token_issuance_log (trx_id, recipient, units, status, error_message, rationale)
-                                VALUES (%s, %s, %s, %s, NULL, %s)
-                                """,
-                                (trx_id, token_recipient, transferable_units, "SUCCESS", "Unit Conversion"),
-                            )
-
-
-                    # Refund any excess units if any
-                    if refunded_units > 0:
-                        print(
-                            f"[PointTransfer] Refunding excess units: trx_id={trx_id} refund_units={refunded_units}"
-                        )
-                        self._refund_excess_transfer(
-                            recipient=sender,
-                            refund_units=refunded_units,
-                            symbol=amount_obj.symbol,
-                            nominee=nominee,
-                            op=op,
-                        )
-
                     print(
-                        f"[PointTransfer] Completed HBD transfer: trx_id={trx_id} nominee={nominee} units={transferable_units}"
+                        f"[PointTransfer] Issuing default tokens: source_trx_id={trx_id} "
+                        f"recipient={token_recipient} units={transferable_units}"
                     )
-                    return True
+                    try:
+                        tx = issue_default_tokens(token_recipient, transferable_units)
+                        issue_trx_id = _issue_trx_id(tx)
+                    except Exception as e:
+                        log.exception(
+                            "Failed to issue default tokens for %s (%s units)",
+                            token_recipient,
+                            transferable_units,
+                        )
+                        with db2.engine.begin() as conn:
+                            _record_token_issuance_error(conn, log_id, str(e))
+                    else:
+                        log.info("Issued %d HSBI tokens to %s", transferable_units, sender)
+                        with db2.engine.begin() as conn:
+                            _mark_token_issuance_success(conn, log_id, issue_trx_id)
+
+                # Refund any excess units if any
+                if refunded_units > 0:
+                    print(
+                        f"[PointTransfer] Refunding excess units: trx_id={trx_id} refund_units={refunded_units}"
+                    )
+                    self._refund_excess_transfer(
+                        recipient=sender,
+                        refund_units=refunded_units,
+                        symbol=amount_obj.symbol,
+                        nominee=nominee,
+                        op=op,
+                    )
+
+                print(
+                    f"[PointTransfer] Completed HBD transfer: trx_id={trx_id} nominee={nominee} units={transferable_units}"
+                )
+                return True
 
         # HIVE rshares transfer a.k.a Lovegun point transfer
         old_sender_rshares = sender_member["balance_rshares"]

--- a/hivesbi/parse_hist_op.py
+++ b/hivesbi/parse_hist_op.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 
 from nectar.account import Account
 from nectar.amount import Amount
@@ -13,57 +13,20 @@ from nectar.utils import (
     formatTimeString,
 )
 
+from hivesbi.issuance_log import (
+    has_issuance_for_source,
+    insert_pending_issuance as _insert_pending_token_issuance,
+    issue_trx_id as _issue_trx_id,
+    mark_issuance_success as _mark_token_issuance_success,
+    record_pending_error as _record_token_issuance_error,
+)
 from hivesbi.issue import TokenIssuer, issue_default_tokens
 from hivesbi.memo_parser import MemoParser
 from hivesbi.settings import get_runtime
 
 log = logging.getLogger(__name__)
 
-PENDING_TRX_PLACEHOLDER = "PENDING"
 UNIT_CONVERSION_RATIONALE = "Unit Conversion"
-
-
-def _issue_trx_id(tx):
-    return tx.get("trx_id") or tx.get("transaction_id") or "N/A"
-
-
-def _insert_pending_token_issuance(
-    conn, recipient, units, rationale, source_trx_id=None
-):
-    result = conn.exec_driver_sql(
-        """
-        INSERT INTO token_issuance_log
-            (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id)
-        VALUES (%s, %s, %s, %s, 'PENDING', NULL, %s, %s)
-        """,
-        (
-            PENDING_TRX_PLACEHOLDER,
-            recipient,
-            units,
-            datetime.now(timezone.utc),
-            rationale,
-            source_trx_id,
-        ),
-    )
-    return result.lastrowid
-
-
-def _mark_token_issuance_success(conn, log_id, trx_id):
-    conn.exec_driver_sql(
-        """
-        UPDATE token_issuance_log
-        SET status = 'SUCCESS', trx_id = %s, error_message = NULL
-        WHERE id = %s
-        """,
-        (trx_id, log_id),
-    )
-
-
-def _record_token_issuance_error(conn, log_id, error_message):
-    conn.exec_driver_sql(
-        "UPDATE token_issuance_log SET error_message = %s WHERE id = %s",
-        (error_message, log_id),
-    )
 
 
 class ParseAccountHist(list):
@@ -764,33 +727,47 @@ class ParseAccountHist(list):
                 # Issue default tokens to the sender if nominee is sbi-tokens.
                 if nominee == "sbi-tokens":
                     token_recipient = sender
+                    # Guard + intent insert in one transaction: a reprocessed
+                    # transfer op (crash between broadcast and op bookkeeping)
+                    # must not mint the same source transaction twice.
                     with db2.engine.begin() as conn:
-                        log_id = _insert_pending_token_issuance(
-                            conn,
-                            token_recipient,
-                            transferable_units,
-                            UNIT_CONVERSION_RATIONALE,
-                            source_trx_id=trx_id,
+                        if has_issuance_for_source(
+                            conn, trx_id, UNIT_CONVERSION_RATIONALE
+                        ):
+                            log_id = None
+                        else:
+                            log_id = _insert_pending_token_issuance(
+                                conn,
+                                token_recipient,
+                                transferable_units,
+                                UNIT_CONVERSION_RATIONALE,
+                                source_trx_id=trx_id,
+                            )
+                    if log_id is None:
+                        print(
+                            "[PointTransfer] Skipping duplicate Unit Conversion "
+                            f"issuance: source_trx_id={trx_id}"
                         )
-                    print(
-                        f"[PointTransfer] Issuing default tokens: source_trx_id={trx_id} "
-                        f"recipient={token_recipient} units={transferable_units}"
-                    )
-                    try:
-                        tx = issue_default_tokens(token_recipient, transferable_units)
-                        issue_trx_id = _issue_trx_id(tx)
-                    except Exception as e:
-                        log.exception(
-                            "Failed to issue default tokens for %s (%s units)",
-                            token_recipient,
-                            transferable_units,
-                        )
-                        with db2.engine.begin() as conn:
-                            _record_token_issuance_error(conn, log_id, str(e))
                     else:
-                        log.info("Issued %d HSBI tokens to %s", transferable_units, sender)
-                        with db2.engine.begin() as conn:
-                            _mark_token_issuance_success(conn, log_id, issue_trx_id)
+                        print(
+                            f"[PointTransfer] Issuing default tokens: source_trx_id={trx_id} "
+                            f"recipient={token_recipient} units={transferable_units}"
+                        )
+                        try:
+                            tx = issue_default_tokens(token_recipient, transferable_units)
+                            issue_trx_id = _issue_trx_id(tx)
+                        except Exception as e:
+                            log.exception(
+                                "Failed to issue default tokens for %s (%s units)",
+                                token_recipient,
+                                transferable_units,
+                            )
+                            with db2.engine.begin() as conn:
+                                _record_token_issuance_error(conn, log_id, str(e))
+                        else:
+                            log.info("Issued %d HSBI tokens to %s", transferable_units, sender)
+                            with db2.engine.begin() as conn:
+                                _mark_token_issuance_success(conn, log_id, issue_trx_id)
 
                 # Refund any excess units if any
                 if refunded_units > 0:

--- a/hsbi_check_delegation.py
+++ b/hsbi_check_delegation.py
@@ -93,8 +93,13 @@ def clear_virtual_tokens(conn, accounts):
         upsert_virtual_tokens(conn, account, Decimal("0.000"))
 
 
-def refresh_management_virtual_tokens(conn):
-    """Set Management virtual_tokens to 10% of all other virtual_tokens."""
+def refresh_management_virtual_tokens(conn, own_delegation_virtual=Decimal("0.000")):
+    """Set Management virtual_tokens to 10% of all other virtual_tokens.
+
+    `own_delegation_virtual` preserves any delegation-derived virtual tokens the
+    management account earned as an ordinary delegator (2x its delegated HP);
+    the derived 10% is added on top instead of overwriting that grant.
+    """
     non_management_virtual = conn.exec_driver_sql(
         """
         SELECT COALESCE(SUM(virtual_tokens), 0)
@@ -103,7 +108,9 @@ def refresh_management_virtual_tokens(conn):
         """,
         (MANAGEMENT_VIRTUAL_RECIPIENT,),
     ).scalar()
-    management_virtual = calculate_management_virtual_tokens(non_management_virtual)
+    management_virtual = calculate_management_virtual_tokens(
+        non_management_virtual
+    ) + Decimal(str(own_delegation_virtual))
     upsert_virtual_tokens(conn, MANAGEMENT_VIRTUAL_RECIPIENT, management_virtual)
     return management_virtual
 
@@ -260,13 +267,25 @@ def run():
                 last_delegation_check = delegation_timestamp[acc]
             print(f"hsbi_check_delegation: will clear virtual_tokens for {acc}")
 
+        # The management account may also be an ordinary delegator; its own
+        # delegation-derived virtual tokens (from the current trx delegation
+        # state) are preserved on top of the derived 10% allocation.
+        management_delegation_hp = delegation.get(MANAGEMENT_VIRTUAL_RECIPIENT, 0)
+        management_own_virtual = (
+            calculate_virtual_tokens(management_delegation_hp)
+            if management_delegation_hp
+            else Decimal("0.000")
+        )
+
         # Apply all delegation token changes atomically in one batched transaction,
         # then refresh the derived Management virtual token allocation.
         with db2.engine.begin() as conn:
             if active_virtual or zero_virtual:
                 apply_active_delegations(conn, account, active_virtual)
                 clear_virtual_tokens(conn, zero_virtual)
-            management_virtual = refresh_management_virtual_tokens(conn)
+            management_virtual = refresh_management_virtual_tokens(
+                conn, management_own_virtual
+            )
             print(
                 "hsbi_check_delegation: set "
                 f"{MANAGEMENT_VIRTUAL_RECIPIENT} virtual_tokens to {management_virtual}"

--- a/hsbi_check_delegation.py
+++ b/hsbi_check_delegation.py
@@ -9,6 +9,9 @@ from hivesbi.storage import ConfigurationDB, TrxDB
 from hivesbi.transfer_ops_storage import TransferTrx
 from hivesbi.utils import ensure_timezone_aware
 
+MANAGEMENT_VIRTUAL_RECIPIENT = "josephsavage"
+MANAGEMENT_VIRTUAL_RATE = Decimal("0.10")
+
 
 def calculate_shares(delegation_shares, hp_share_ratio):
     """Convert delegated HP into delegation bonus *shares* (HP / sp_share_ratio).
@@ -25,6 +28,12 @@ def calculate_shares(delegation_shares, hp_share_ratio):
 
 def calculate_virtual_tokens(delegated_hp):
     return (Decimal(str(delegated_hp)) * Decimal("2")).quantize(
+        Decimal("0.001"), rounding=ROUND_HALF_UP
+    )
+
+
+def calculate_management_virtual_tokens(non_management_virtual_tokens):
+    return (Decimal(str(non_management_virtual_tokens)) * MANAGEMENT_VIRTUAL_RATE).quantize(
         Decimal("0.001"), rounding=ROUND_HALF_UP
     )
 
@@ -82,6 +91,21 @@ def clear_virtual_tokens(conn, accounts):
     """Set virtual_tokens to 0 for removed/leased delegators."""
     for account in accounts:
         upsert_virtual_tokens(conn, account, Decimal("0.000"))
+
+
+def refresh_management_virtual_tokens(conn):
+    """Set Management virtual_tokens to 10% of all other virtual_tokens."""
+    non_management_virtual = conn.exec_driver_sql(
+        """
+        SELECT COALESCE(SUM(virtual_tokens), 0)
+        FROM tokenholders
+        WHERE member_name <> %s
+        """,
+        (MANAGEMENT_VIRTUAL_RECIPIENT,),
+    ).scalar()
+    management_virtual = calculate_management_virtual_tokens(non_management_virtual)
+    upsert_virtual_tokens(conn, MANAGEMENT_VIRTUAL_RECIPIENT, management_virtual)
+    return management_virtual
 
 
 def run():
@@ -236,11 +260,17 @@ def run():
                 last_delegation_check = delegation_timestamp[acc]
             print(f"hsbi_check_delegation: will clear virtual_tokens for {acc}")
 
-        # Apply all delegation token changes atomically in one batched transaction.
-        if active_virtual or zero_virtual:
-            with db2.engine.begin() as conn:
+        # Apply all delegation token changes atomically in one batched transaction,
+        # then refresh the derived Management virtual token allocation.
+        with db2.engine.begin() as conn:
+            if active_virtual or zero_virtual:
                 apply_active_delegations(conn, account, active_virtual)
                 clear_virtual_tokens(conn, zero_virtual)
+            management_virtual = refresh_management_virtual_tokens(conn)
+            print(
+                "hsbi_check_delegation: set "
+                f"{MANAGEMENT_VIRTUAL_RECIPIENT} virtual_tokens to {management_virtual}"
+            )
 
         dd = delegation
         for d in dd:

--- a/hsbi_token_snapshot.py
+++ b/hsbi_token_snapshot.py
@@ -5,6 +5,18 @@ from datetime import datetime, timedelta, timezone
 from hivesbi.settings import get_runtime
 from hivesbi.storage import ConfigurationDB
 from hivesbi.utils import ensure_timezone_aware
+from hivesbi.issuance_log import (
+    PENDING_TRX_PLACEHOLDER,
+    UNCAPTURED_TRX_PLACEHOLDER,
+    complete_uncaptured_success,
+    insert_pending_issuance,
+    issue_trx_id,
+    log_issuance,
+    mark_issuance_failure,
+    mark_issuance_success,
+    record_pending_error,
+    utcnow,
+)
 from hivesbi.issue import (
     get_tokenholders,
     get_default_token_issuer,
@@ -26,8 +38,7 @@ ABC_RATIONALE = "Pending Balance Conversion"
 CHAIN_MATCH_WINDOW = timedelta(minutes=30)
 CHAIN_SCAN_LOOKBACK = timedelta(hours=5)
 HISTORY_SCAN_LIMIT = 1000
-PENDING_TRX_PLACEHOLDER = "PENDING"
-UNCAPTURED_TRX_PLACEHOLDER = "N/A"
+HISTORY_SCAN_HARD_LIMIT = 10000
 MATCH_CLOCK_SKEW = timedelta(minutes=5)
 
 
@@ -37,14 +48,6 @@ def token_decimal(value):
 
 def floor_token_amount(value):
     return token_decimal(value).quantize(TOKEN_PRECISION, rounding=ROUND_DOWN)
-
-
-def utcnow():
-    return datetime.now(timezone.utc)
-
-
-def issue_trx_id(tx):
-    return tx.get("trx_id") or tx.get("transaction_id") or UNCAPTURED_TRX_PLACEHOLDER
 
 
 def calculate_management_issue_amount(outstanding, management_issued):
@@ -61,93 +64,9 @@ def calculate_management_issue_amount(outstanding, management_issued):
 
 
 # ---------------------------------------------------------------------------
-# write-ahead issuance log helpers
-# ---------------------------------------------------------------------------
-# Every issuance path commits an intent row before broadcasting. The broadcast is
-# the only step that cannot be rolled back, so reconciliation completes the same
-# row from chain history if the process dies before SUCCESS is recorded. rationale
-# is durable and is never inferred from chain history.
-
-
-def insert_pending_issuance(
-    conn, recipient, units, rationale, source_trx_id=None, issued_at=None
-):
-    issued_at = issued_at or utcnow()
-    result = conn.exec_driver_sql(
-        """
-        INSERT INTO token_issuance_log
-            (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id)
-        VALUES (%s, %s, %s, %s, 'PENDING', NULL, %s, %s)
-        """,
-        (PENDING_TRX_PLACEHOLDER, recipient, units, issued_at, rationale, source_trx_id),
-    )
-    return result.lastrowid
-
-
-def mark_issuance_success(conn, log_id, trx_id):
-    conn.exec_driver_sql(
-        """
-        UPDATE token_issuance_log
-        SET status = 'SUCCESS', trx_id = %s, error_message = NULL
-        WHERE id = %s
-        """,
-        (trx_id, log_id),
-    )
-
-
-def complete_uncaptured_success(conn, log_id, trx_id):
-    conn.exec_driver_sql(
-        "UPDATE token_issuance_log SET trx_id = %s, error_message = NULL WHERE id = %s",
-        (trx_id, log_id),
-    )
-
-
-def mark_issuance_failure(conn, log_id, error_message):
-    conn.exec_driver_sql(
-        "UPDATE token_issuance_log SET status = 'FAILURE', error_message = %s WHERE id = %s",
-        (error_message, log_id),
-    )
-
-
-def record_pending_error(conn, log_id, error_message):
-    """Keep a row PENDING (so it still guards against re-issue) but note the error.
-
-    A broadcast that raised may still have reached the chain, so we do not assume
-    failure here — chain reconciliation resolves the row to SUCCESS or FAILURE.
-    """
-    conn.exec_driver_sql(
-        "UPDATE token_issuance_log SET error_message = %s WHERE id = %s",
-        (error_message, log_id),
-    )
-
-
-def log_issuance(
-    conn,
-    trx_id,
-    recipient,
-    units,
-    status,
-    rationale,
-    error_message=None,
-    source_trx_id=None,
-    issued_at=None,
-):
-    """Append a terminal (SUCCESS/FAILURE) issuance row.
-
-    Retained for legacy tests and historical compatibility; new issuance paths
-    should use insert_pending_issuance followed by mark_issuance_success.
-    """
-    issued_at = issued_at or utcnow()
-    conn.exec_driver_sql(
-        """
-        INSERT INTO token_issuance_log
-            (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-        """,
-        (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id),
-    )
-
-
+# write-ahead issuance log helpers live in hivesbi.issuance_log (shared with
+# hivesbi.parse_hist_op for Unit Conversion); they are re-exported above for
+# callers and tests.
 # ---------------------------------------------------------------------------
 # chain-confirm reconciliation
 # ---------------------------------------------------------------------------
@@ -213,7 +132,8 @@ def _parse_engine_issue(history_row, token_symbol="HSBIDAO"):
 def fetch_recent_chain_issuance_scan(
     issuer, token_symbol="HSBIDAO", limit=HISTORY_SCAN_LIMIT, lookback=CHAIN_SCAN_LOOKBACK
 ):
-    cutoff = utcnow() - lookback
+    scan_started = utcnow()
+    cutoff = scan_started - lookback
     try:
         history = issuer.hive_account.history_reverse(only_ops=["custom_json"])
     except TypeError:
@@ -230,7 +150,6 @@ def fetch_recent_chain_issuance_scan(
     scanned = 0
     reached_cutoff = False
     saw_timestamp = False
-    covered_until = None
     for history_row in history:
         scanned += 1
         if scanned > limit:
@@ -239,8 +158,6 @@ def fetch_recent_chain_issuance_scan(
         timestamp = ensure_timezone_aware(row.get("timestamp") or op.get("timestamp"))
         if timestamp is not None:
             saw_timestamp = True
-            if covered_until is None or timestamp > covered_until:
-                covered_until = timestamp
         if timestamp is not None and timestamp < cutoff:
             reached_cutoff = True
             break
@@ -251,10 +168,15 @@ def fetch_recent_chain_issuance_scan(
     complete = reached_cutoff or scanned < limit
     if reached_cutoff:
         covered_since = cutoff
-    elif complete and saw_timestamp:
+    elif complete and (saw_timestamp or scanned == 0):
         covered_since = datetime.min.replace(tzinfo=timezone.utc)
     else:
         covered_since = None
+    # history_reverse starts at the account head, so a successful fetch covers
+    # everything up to the present: no op newer than the newest scanned op can
+    # exist. The skew margin absorbs API indexing lag and chain-vs-app clock
+    # drift, so an issuer with no recent activity can still prove absence.
+    covered_until = scan_started - MATCH_CLOCK_SKEW
     return {
         "issuances": issuances,
         "covered_since": covered_since,
@@ -414,7 +336,6 @@ def _complete_balance_issuance_effect(conn, pending_row):
 def reconcile_issuances(
     conn,
     chain_issuances,
-    now=None,
     covered_since=None,
     covered_until=None,
     scan_complete=False,
@@ -424,13 +345,14 @@ def reconcile_issuances(
     Reconciliation uses the blockchain timestamp as the authority. A PENDING row
     is confirmed only by a matching chain issue (recipient + units + chain
     timestamp near the intent timestamp). A PENDING row is failed only when the
-    chain scan provably covered its entire possible match window.
+    chain scan provably covered its entire possible match window AND no in-window
+    chain issue could plausibly be its broadcast (a contested row stays PENDING;
+    once the sibling SUCCESS row records the chain trx_id, the next pass excludes
+    that issue and the row resolves).
 
     rationale is read from the existing PENDING row and is never inferred from the
     chain or rewritten.
     """
-    now = now or utcnow()
-
     logged_trx = {
         r[0]
         for r in conn.exec_driver_sql(
@@ -461,6 +383,20 @@ def reconcile_issuances(
     ]
     matches, matched_trx_ids = _match_pending_rows_to_chain(pending, unmatched_chain)
 
+    # A pending row with any in-window chain candidate is contested: that issue
+    # may be its own broadcast (tie-skipped, or attributed to a sibling row by
+    # timestamp proximity), so absence is not proven and the row must not be
+    # failed this pass.
+    contested = {
+        row["id"]
+        for row in pending
+        if row["id"] not in matches
+        and any(
+            _chain_issue_matches_pending(chain_issue, row)
+            for chain_issue in unmatched_chain
+        )
+    }
+
     for pending_row in pending:
         log_id = pending_row["id"]
         recipient = pending_row["recipient"]
@@ -485,6 +421,11 @@ def reconcile_issuances(
             and covered_since <= issued_at_aware - MATCH_CLOCK_SKEW
             and covered_until >= issued_at_aware + CHAIN_MATCH_WINDOW
         )
+        if scan_covers_row and log_id in contested:
+            print(
+                f"Leaving contested PENDING unresolved: {recipient} {units} {rationale}"
+            )
+            continue
         if scan_covers_row:
             mark_issuance_failure(
                 conn,
@@ -536,7 +477,17 @@ def reconcile_recent_issuances(db2, issuer):
         if needed > lookback:
             lookback = needed
 
-    scan = fetch_recent_chain_issuance_scan(issuer, lookback=lookback)
+    # Scale the scan budget with the lookback: a fixed limit on a busy issuer
+    # (one custom_json per member issuance) would stop the scan before the
+    # cutoff, complete=False forever, and old PENDING rows could never resolve.
+    limit = HISTORY_SCAN_LIMIT
+    if lookback > CHAIN_SCAN_LOOKBACK:
+        limit = min(
+            int(HISTORY_SCAN_LIMIT * (lookback / CHAIN_SCAN_LOOKBACK)) + 1,
+            HISTORY_SCAN_HARD_LIMIT,
+        )
+
+    scan = fetch_recent_chain_issuance_scan(issuer, lookback=lookback, limit=limit)
     with db2.engine.begin() as conn:
         reconcile_issuances(
             conn,

--- a/hsbi_token_snapshot.py
+++ b/hsbi_token_snapshot.py
@@ -36,10 +36,39 @@ MANAGEMENT_RATIONALE = "Management"
 PIK_RATIONALE = "pik"
 ABC_RATIONALE = "Pending Balance Conversion"
 CHAIN_MATCH_WINDOW = timedelta(minutes=30)
-CHAIN_SCAN_LOOKBACK = timedelta(hours=5)
-HISTORY_SCAN_LIMIT = 1000
-HISTORY_SCAN_HARD_LIMIT = 10000
+# Floor only: reconcile_recent_issuances extends the lookback to cover the oldest
+# PENDING row. PENDING resolution is therefore self-correcting and does NOT depend
+# on this value — the audit-only passes do ('N/A' completion and the
+# unexplained-issuance warning), and those act on SUCCESS rows, which never extend
+# the lookback themselves.
+#
+# DO NOT LOWER. The hard minimum is one full cycle plus the match window:
+# share_cycle_min (144 min) + CHAIN_MATCH_WINDOW + MATCH_CLOCK_SKEW ~= 2.98h. Below
+# that, a SUCCESS row logged with UNCAPTURED_TRX_PLACEHOLDER in the previous cycle
+# falls outside the scan and keeps its placeholder forever. 6h leaves 5.42h after
+# the 35-minute margin = ~2.26 cycles, so every uncaptured row gets two full
+# reconciliation passes and a missed pass is not permanent coverage loss (5h gave
+# only 1.84 cycles — one pass plus a partial). The cost is paid in the high-VP
+# regime, where the cycle fires every ~15 min and the window is re-walked ~24x.
+CHAIN_SCAN_LOOKBACK = timedelta(hours=6)
+# The scan breaks at `reached_cutoff`, so these are a runaway guard, not a budget:
+# an ordinary cycle exits after a few hundred ops no matter how high they are set.
+# They only bind in the high-VP regime, where the cycle fires roughly every 15
+# minutes instead of every 144. Measured peak (2026-07-14) was 1597 issuances in a
+# 5h window at current membership; the scan window is 6h, so budget ~5x the peak
+# for membership growth. Note this counts EVERY custom_json on the issuer account,
+# including hsbi_liquidpools broadcasts that never reach token_issuance_log — the
+# measured figure is a floor. Below the real peak `complete` is always False, no
+# PENDING row can ever be failed, and issue_balance_tokens then skips that member
+# every cycle.
+HISTORY_SCAN_LIMIT = 10000
+HISTORY_SCAN_HARD_LIMIT = 50000
 MATCH_CLOCK_SKEW = timedelta(minutes=5)
+# A PENDING row older than two 144-minute cycles means reconciliation is not
+# converging. The row blocks its (recipient, rationale) in issue_balance_tokens and
+# the symptom is silent — a skipped member raises no error, it just stops being
+# paid — so it has to be announced.
+STUCK_PENDING_AGE = timedelta(hours=6)
 
 
 def token_decimal(value):
@@ -216,6 +245,10 @@ def _chain_issue_matches_logged_success(chain_issue, success_row):
     return issued_at - MATCH_CLOCK_SKEW <= chain_timestamp <= issued_at + CHAIN_MATCH_WINDOW
 
 
+def _chain_sort_key(chain_issue):
+    return chain_issue.get("timestamp") or datetime.max.replace(tzinfo=timezone.utc)
+
+
 def _match_pending_rows_to_chain(pending_rows, chain_issuances):
     """Match on-chain issues to the closest compatible PENDING row.
 
@@ -228,10 +261,7 @@ def _match_pending_rows_to_chain(pending_rows, chain_issuances):
     used_log_ids = set()
     used_trx_ids = set()
 
-    def chain_sort_key(chain_issue):
-        return chain_issue.get("timestamp") or datetime.max.replace(tzinfo=timezone.utc)
-
-    for chain_issue in sorted(chain_issuances, key=chain_sort_key):
+    for chain_issue in sorted(chain_issuances, key=_chain_sort_key):
         candidates = [
             row
             for row in pending_rows
@@ -362,6 +392,37 @@ def reconcile_issuances(
     }
     unmatched_chain = [c for c in chain_issuances if c["trx_id"] not in logged_trx]
 
+    # Pass 1 — adopt chain issues that provably belong to an existing SUCCESS row
+    # whose broadcast returned no trx_id (logged UNCAPTURED_TRX_PLACEHOLDER).
+    #
+    # This MUST run before pending matching. A chain issue left in the pool here
+    # can be handed to an unrelated PENDING row of the same recipient and amount,
+    # stamping that row with a trx_id belonging to a different issuance while the
+    # real uncaptured row keeps its placeholder forever.
+    completed_trx_ids = set()
+    completed_log_ids = set()
+    for chain_issue in sorted(unmatched_chain, key=_chain_sort_key):
+        uncaptured = _find_logged_success_for_chain_issue(
+            conn, chain_issue, trx_id=UNCAPTURED_TRX_PLACEHOLDER
+        )
+        # The UPDATE below clears the placeholder, so a completed row cannot be
+        # re-selected; completed_log_ids guards the same invariant explicitly.
+        if uncaptured is None or uncaptured["id"] in completed_log_ids:
+            continue
+        complete_uncaptured_success(conn, uncaptured["id"], chain_issue["trx_id"])
+        completed_log_ids.add(uncaptured["id"])
+        completed_trx_ids.add(chain_issue["trx_id"])
+        print(
+            "Completed logged issuance from chain: "
+            f"{chain_issue['trx_id']} {chain_issue['recipient']} "
+            f"{chain_issue['units']} {uncaptured['rationale']}"
+        )
+
+    unmatched_chain = [
+        c for c in unmatched_chain if c["trx_id"] not in completed_trx_ids
+    ]
+
+    # Pass 2 — resolve write-ahead PENDING rows against what is left.
     pending_rows = conn.exec_driver_sql(
         """
         SELECT id, recipient, units, rationale, issued_at
@@ -434,22 +495,13 @@ def reconcile_issuances(
             )
             print(f"Reconciled PENDING -> FAILURE: {recipient} {units} {rationale}")
 
+    # Pass 3 — anything still unclaimed is either already explained by a logged
+    # SUCCESS row (nothing to do) or has no origin in the log at all (report only;
+    # never insert, or the log double-counts the issuance — see CHANGES.md, #138).
     unmatched_chain = [
         c for c in unmatched_chain if c["trx_id"] not in matched_trx_ids
     ]
     for chain_issue in unmatched_chain:
-        uncaptured = _find_logged_success_for_chain_issue(
-            conn, chain_issue, trx_id=UNCAPTURED_TRX_PLACEHOLDER
-        )
-        if uncaptured is not None:
-            complete_uncaptured_success(conn, uncaptured["id"], chain_issue["trx_id"])
-            print(
-                "Completed logged issuance from chain: "
-                f"{chain_issue['trx_id']} {chain_issue['recipient']} "
-                f"{chain_issue['units']} {uncaptured['rationale']}"
-            )
-            continue
-
         explained = _find_logged_success_for_chain_issue(conn, chain_issue)
         if explained is not None:
             print(
@@ -463,6 +515,30 @@ def reconcile_issuances(
             "Unexplained on-chain issuance without token_issuance_log origin: "
             f"{chain_issue['trx_id']} {chain_issue['recipient']} {chain_issue['units']}"
         )
+
+
+def warn_stuck_pending(conn):
+    """Announce PENDING rows that reconciliation should already have resolved.
+
+    issue_balance_tokens skips any member holding a live PENDING row for the same
+    rationale, so an unresolvable row silently stops that member's dividends. The
+    usual cause is an incomplete chain scan (see HISTORY_SCAN_LIMIT).
+    """
+    rows = conn.exec_driver_sql(
+        """
+        SELECT id, recipient, units, rationale, issued_at, error_message
+        FROM token_issuance_log
+        WHERE status = 'PENDING' AND issued_at < %s
+        ORDER BY issued_at ASC
+        """,
+        (utcnow() - STUCK_PENDING_AGE,),
+    ).fetchall()
+    for row in rows:
+        print(
+            f"ALERT: stuck PENDING issuance id={row[0]} recipient={row[1]} "
+            f"units={row[2]} rationale={row[3]} issued_at={row[4]} error={row[5]}"
+        )
+    return len(rows)
 
 
 def reconcile_recent_issuances(db2, issuer):
@@ -488,6 +564,20 @@ def reconcile_recent_issuances(db2, issuer):
         )
 
     scan = fetch_recent_chain_issuance_scan(issuer, lookback=lookback, limit=limit)
+    if not scan["complete"]:
+        print(
+            "ALERT: chain issuance scan incomplete "
+            f"(lookback={lookback}, limit={limit}). No PENDING row can be failed "
+            "this pass, so affected members stay blocked in issue_balance_tokens. "
+            "Raise HISTORY_SCAN_LIMIT if this persists."
+        )
+    if limit >= HISTORY_SCAN_HARD_LIMIT:
+        print(
+            f"ALERT: chain scan lookback hit HISTORY_SCAN_HARD_LIMIT ({limit}); "
+            f"oldest PENDING issued_at={oldest_pending}. Reconciliation may never "
+            "converge — investigate before the next cycle."
+        )
+
     with db2.engine.begin() as conn:
         reconcile_issuances(
             conn,
@@ -496,6 +586,7 @@ def reconcile_recent_issuances(db2, issuer):
             covered_until=scan["covered_until"],
             scan_complete=scan["complete"],
         )
+        warn_stuck_pending(conn)
 
 
 # ---------------------------------------------------------------------------

--- a/hsbi_token_snapshot.py
+++ b/hsbi_token_snapshot.py
@@ -23,11 +23,11 @@ MANAGEMENT_RECIPIENT = "josephsavage"
 MANAGEMENT_RATIONALE = "Management"
 PIK_RATIONALE = "pik"
 ABC_RATIONALE = "Pending Balance Conversion"
-RECONCILED_RATIONALE = "reconciled"
-
-RECONCILIATION_WINDOW = timedelta(hours=5)
+CHAIN_MATCH_WINDOW = timedelta(minutes=30)
+CHAIN_SCAN_LOOKBACK = timedelta(hours=5)
 HISTORY_SCAN_LIMIT = 1000
 PENDING_TRX_PLACEHOLDER = "PENDING"
+UNCAPTURED_TRX_PLACEHOLDER = "N/A"
 MATCH_CLOCK_SKEW = timedelta(minutes=5)
 
 
@@ -37,6 +37,14 @@ def token_decimal(value):
 
 def floor_token_amount(value):
     return token_decimal(value).quantize(TOKEN_PRECISION, rounding=ROUND_DOWN)
+
+
+def utcnow():
+    return datetime.now(timezone.utc)
+
+
+def issue_trx_id(tx):
+    return tx.get("trx_id") or tx.get("transaction_id") or UNCAPTURED_TRX_PLACEHOLDER
 
 
 def calculate_management_issue_amount(outstanding, management_issued):
@@ -53,37 +61,43 @@ def calculate_management_issue_amount(outstanding, management_issued):
 
 
 # ---------------------------------------------------------------------------
-# write-ahead issuance log helpers (Management issuance only)
+# write-ahead issuance log helpers
 # ---------------------------------------------------------------------------
-# Only the Management 10% issuance uses the write-ahead protocol, because it is
-# capped (a double issuance permanently over-mints) and has no per-member balance
-# to retry against. The Management broadcast is preceded by a committed PENDING row
-# carrying rationale='Management'; the cap counts PENDING+SUCCESS so a crash after
-# broadcast cannot re-issue, and chain reconciliation later resolves the row to
-# SUCCESS or FAILURE. status moves PENDING -> SUCCESS/FAILURE; rationale never
-# changes.
-#
-# Per-member pik / abc_pik issuance deliberately does NOT use this protocol — it is
-# immediate and self-healing (see issue_balance_tokens): a failed broadcast simply
-# leaves the balance to be retried next cycle, so a transient failure can never
-# permanently strand a member's dividends behind an unresolved PENDING row.
+# Every issuance path commits an intent row before broadcasting. The broadcast is
+# the only step that cannot be rolled back, so reconciliation completes the same
+# row from chain history if the process dies before SUCCESS is recorded. rationale
+# is durable and is never inferred from chain history.
 
 
-def insert_pending_issuance(conn, recipient, units, rationale):
+def insert_pending_issuance(
+    conn, recipient, units, rationale, source_trx_id=None, issued_at=None
+):
+    issued_at = issued_at or utcnow()
     result = conn.exec_driver_sql(
         """
         INSERT INTO token_issuance_log
-            (trx_id, recipient, units, status, error_message, rationale)
-        VALUES (%s, %s, %s, 'PENDING', NULL, %s)
+            (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id)
+        VALUES (%s, %s, %s, %s, 'PENDING', NULL, %s, %s)
         """,
-        (PENDING_TRX_PLACEHOLDER, recipient, units, rationale),
+        (PENDING_TRX_PLACEHOLDER, recipient, units, issued_at, rationale, source_trx_id),
     )
     return result.lastrowid
 
 
 def mark_issuance_success(conn, log_id, trx_id):
     conn.exec_driver_sql(
-        "UPDATE token_issuance_log SET status = 'SUCCESS', trx_id = %s WHERE id = %s",
+        """
+        UPDATE token_issuance_log
+        SET status = 'SUCCESS', trx_id = %s, error_message = NULL
+        WHERE id = %s
+        """,
+        (trx_id, log_id),
+    )
+
+
+def complete_uncaptured_success(conn, log_id, trx_id):
+    conn.exec_driver_sql(
+        "UPDATE token_issuance_log SET trx_id = %s, error_message = NULL WHERE id = %s",
         (trx_id, log_id),
     )
 
@@ -107,19 +121,30 @@ def record_pending_error(conn, log_id, error_message):
     )
 
 
-def log_issuance(conn, trx_id, recipient, units, status, rationale, error_message=None):
+def log_issuance(
+    conn,
+    trx_id,
+    recipient,
+    units,
+    status,
+    rationale,
+    error_message=None,
+    source_trx_id=None,
+    issued_at=None,
+):
     """Append a terminal (SUCCESS/FAILURE) issuance row.
 
-    Used by the immediate pik / abc_pik path, which logs the outcome directly
-    rather than going through the Management write-ahead PENDING protocol.
+    Retained for legacy tests and historical compatibility; new issuance paths
+    should use insert_pending_issuance followed by mark_issuance_success.
     """
+    issued_at = issued_at or utcnow()
     conn.exec_driver_sql(
         """
         INSERT INTO token_issuance_log
-            (trx_id, recipient, units, status, error_message, rationale)
-        VALUES (%s, %s, %s, %s, %s, %s)
+            (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
         """,
-        (trx_id, recipient, units, status, error_message, rationale),
+        (trx_id, recipient, units, issued_at, status, error_message, rationale, source_trx_id),
     )
 
 
@@ -186,9 +211,9 @@ def _parse_engine_issue(history_row, token_symbol="HSBIDAO"):
 
 
 def fetch_recent_chain_issuance_scan(
-    issuer, token_symbol="HSBIDAO", limit=HISTORY_SCAN_LIMIT
+    issuer, token_symbol="HSBIDAO", limit=HISTORY_SCAN_LIMIT, lookback=CHAIN_SCAN_LOOKBACK
 ):
-    cutoff = datetime.now(timezone.utc) - RECONCILIATION_WINDOW
+    cutoff = utcnow() - lookback
     try:
         history = issuer.hive_account.history_reverse(only_ops=["custom_json"])
     except TypeError:
@@ -196,15 +221,16 @@ def fetch_recent_chain_issuance_scan(
             history = issuer.hive_account.history_reverse()
         except Exception as exc:
             print(f"Unable to fetch issuer history for reconciliation: {exc}")
-            return {"issuances": [], "covered_since": None, "complete": False}
+            return {"issuances": [], "covered_since": None, "covered_until": None, "complete": False}
     except Exception as exc:
         print(f"Unable to fetch issuer history for reconciliation: {exc}")
-        return {"issuances": [], "covered_since": None, "complete": False}
+        return {"issuances": [], "covered_since": None, "covered_until": None, "complete": False}
 
     issuances = []
     scanned = 0
     reached_cutoff = False
     saw_timestamp = False
+    covered_until = None
     for history_row in history:
         scanned += 1
         if scanned > limit:
@@ -213,6 +239,8 @@ def fetch_recent_chain_issuance_scan(
         timestamp = ensure_timezone_aware(row.get("timestamp") or op.get("timestamp"))
         if timestamp is not None:
             saw_timestamp = True
+            if covered_until is None or timestamp > covered_until:
+                covered_until = timestamp
         if timestamp is not None and timestamp < cutoff:
             reached_cutoff = True
             break
@@ -227,7 +255,12 @@ def fetch_recent_chain_issuance_scan(
         covered_since = datetime.min.replace(tzinfo=timezone.utc)
     else:
         covered_since = None
-    return {"issuances": issuances, "covered_since": covered_since, "complete": complete}
+    return {
+        "issuances": issuances,
+        "covered_since": covered_since,
+        "covered_until": covered_until,
+        "complete": complete,
+    }
 
 
 def fetch_recent_chain_issuances(issuer, token_symbol="HSBIDAO", limit=HISTORY_SCAN_LIMIT):
@@ -244,8 +277,21 @@ def _chain_issue_matches_pending(chain_issue, pending_row):
     chain_timestamp = chain_issue.get("timestamp")
     issued_at = pending_row.get("issued_at")
     if chain_timestamp is None or issued_at is None:
-        return True
-    return issued_at - MATCH_CLOCK_SKEW <= chain_timestamp <= issued_at + RECONCILIATION_WINDOW
+        return False
+    return issued_at - MATCH_CLOCK_SKEW <= chain_timestamp <= issued_at + CHAIN_MATCH_WINDOW
+
+
+def _chain_issue_matches_logged_success(chain_issue, success_row):
+    if chain_issue["recipient"] != success_row["recipient"]:
+        return False
+    if token_decimal(chain_issue["units"]) != success_row["units"]:
+        return False
+
+    chain_timestamp = chain_issue.get("timestamp")
+    issued_at = success_row.get("issued_at")
+    if chain_timestamp is None or issued_at is None:
+        return False
+    return issued_at - MATCH_CLOCK_SKEW <= chain_timestamp <= issued_at + CHAIN_MATCH_WINDOW
 
 
 def _match_pending_rows_to_chain(pending_rows, chain_issuances):
@@ -275,21 +321,94 @@ def _match_pending_rows_to_chain(pending_rows, chain_issuances):
 
         chain_timestamp = chain_issue.get("timestamp")
         if chain_timestamp is None:
-            timestamped_candidates = [row for row in candidates if row.get("issued_at")]
-            if len(timestamped_candidates) != 1:
-                continue
-            best = timestamped_candidates[0]
+            continue
         else:
-            best = min(
+            ranked = sorted(
                 candidates,
-                key=lambda row: abs(chain_timestamp - row["issued_at"])
-                if row.get("issued_at") is not None
-                else RECONCILIATION_WINDOW,
+                key=lambda row: abs(chain_timestamp - row["issued_at"]),
             )
+            if len(ranked) > 1 and abs(
+                chain_timestamp - ranked[0]["issued_at"]
+            ) == abs(chain_timestamp - ranked[1]["issued_at"]):
+                continue
+            best = ranked[0]
         matches[best["id"]] = chain_issue
         used_log_ids.add(best["id"])
         used_trx_ids.add(chain_issue["trx_id"])
     return matches, used_trx_ids
+
+
+def _find_logged_success_for_chain_issue(conn, chain_issue, trx_id=None):
+    params = [
+        chain_issue["recipient"],
+        token_decimal(chain_issue["units"]),
+        PENDING_TRX_PLACEHOLDER,
+    ]
+    trx_filter = ""
+    if trx_id is not None:
+        trx_filter = "AND trx_id = %s"
+        params.append(trx_id)
+
+    rows = conn.exec_driver_sql(
+        f"""
+        SELECT id, recipient, units, rationale, issued_at
+        FROM token_issuance_log
+        WHERE status = 'SUCCESS'
+          AND recipient = %s
+          AND units = %s
+          AND trx_id <> %s
+          {trx_filter}
+        ORDER BY issued_at DESC
+        """,
+        tuple(params),
+    ).fetchall()
+
+    candidates = [
+        {
+            "id": row[0],
+            "recipient": row[1],
+            "units": token_decimal(row[2]),
+            "rationale": row[3],
+            "issued_at": ensure_timezone_aware(row[4]),
+        }
+        for row in rows
+    ]
+    matches = [
+        row
+        for row in candidates
+        if _chain_issue_matches_logged_success(chain_issue, row)
+    ]
+    if not matches:
+        return None
+
+    chain_timestamp = chain_issue.get("timestamp")
+    if chain_timestamp is None:
+        return matches[0]
+    return min(
+        matches,
+        key=lambda row: abs(chain_timestamp - row["issued_at"])
+        if row.get("issued_at") is not None
+        else CHAIN_MATCH_WINDOW,
+    )
+
+
+def _complete_balance_issuance_effect(conn, pending_row):
+    rationale = pending_row["rationale"]
+    if rationale == PIK_RATIONALE:
+        balance_column = "pik"
+    elif rationale == ABC_RATIONALE:
+        balance_column = "abc_pik"
+    else:
+        return
+
+    conn.exec_driver_sql(
+        f"""
+        UPDATE tokenholders
+        SET {balance_column} = GREATEST({balance_column} - %s, 0)
+        WHERE member_name = %s
+        """,
+        (pending_row["units"], pending_row["recipient"]),
+    )
 
 
 def reconcile_issuances(
@@ -297,32 +416,20 @@ def reconcile_issuances(
     chain_issuances,
     now=None,
     covered_since=None,
+    covered_until=None,
     scan_complete=False,
 ):
-    """Resolve Management write-ahead PENDING rows against recent on-chain issuances.
+    """Resolve write-ahead PENDING rows against recent on-chain issuances.
 
-    Only the Management 10% issuance uses the write-ahead PENDING protocol, so this
-    routine is rationale-scoped to Management. Per-member pik / abc_pik issuance is
-    immediate and self-healing (see issue_balance_tokens) and never produces PENDING
-    rows, so it is never touched here.
-
-    - A Management PENDING row that matches an on-chain issuance (same recipient +
-      units, nearest timestamp) is confirmed SUCCESS. Management debits no balance.
-    - A Management PENDING row older than the reconciliation window with no on-chain
-      match — only when the scan provably covered its issued_at — is marked FAILURE
-      so it stops holding down the Management cap and can be re-attempted.
-    - An on-chain issuance with no log row, and not already explained by a confirmed
-      issuance (matched trx_id, or a SUCCESS row of the same recipient + units within
-      the window), is an out-of-band issuance recorded for audit with
-      rationale='reconciled'. It never participates in cap math.
+    Reconciliation uses the blockchain timestamp as the authority. A PENDING row
+    is confirmed only by a matching chain issue (recipient + units + chain
+    timestamp near the intent timestamp). A PENDING row is failed only when the
+    chain scan provably covered its entire possible match window.
 
     rationale is read from the existing PENDING row and is never inferred from the
-    chain or rewritten. Confirmed pik / abc dividends are recognised by their logged
-    trx_id (and, defensively, recipient + units), so a same-amount member dividend to
-    josephsavage is never mistaken for a Management issuance.
+    chain or rewritten.
     """
-    now = now or datetime.now(timezone.utc)
-    stale_before = now - RECONCILIATION_WINDOW
+    now = now or utcnow()
 
     logged_trx = {
         r[0]
@@ -331,29 +438,15 @@ def reconcile_issuances(
             (PENDING_TRX_PLACEHOLDER,),
         ).fetchall()
     }
-    # Confirmed issuances within the window, keyed by (recipient, units). Used to
-    # suppress duplicate orphan audit rows for a pik / abc issuance whose on-chain
-    # trx_id was not captured in its log row.
-    explained = {
-        (r[0], token_decimal(r[1]))
-        for r in conn.exec_driver_sql(
-            """
-            SELECT recipient, units FROM token_issuance_log
-            WHERE status = 'SUCCESS' AND trx_id <> %s AND issued_at >= %s
-            """,
-            (PENDING_TRX_PLACEHOLDER, stale_before),
-        ).fetchall()
-    }
     unmatched_chain = [c for c in chain_issuances if c["trx_id"] not in logged_trx]
 
     pending_rows = conn.exec_driver_sql(
         """
         SELECT id, recipient, units, rationale, issued_at
         FROM token_issuance_log
-        WHERE status = 'PENDING' AND rationale = %s
+        WHERE status = 'PENDING'
         ORDER BY issued_at ASC
-        """,
-        (MANAGEMENT_RATIONALE,),
+        """
     ).fetchall()
 
     pending = [
@@ -368,35 +461,35 @@ def reconcile_issuances(
     ]
     matches, matched_trx_ids = _match_pending_rows_to_chain(pending, unmatched_chain)
 
-    for row in pending_rows:
-        log_id, recipient, units, rationale, issued_at = (
-            row[0],
-            row[1],
-            token_decimal(row[2]),
-            row[3],
-            row[4],
-        )
+    for pending_row in pending:
+        log_id = pending_row["id"]
+        recipient = pending_row["recipient"]
+        units = pending_row["units"]
+        rationale = pending_row["rationale"]
         match = matches.get(log_id)
         if match is not None:
             mark_issuance_success(conn, log_id, match["trx_id"])
+            _complete_balance_issuance_effect(conn, pending_row)
             print(
                 f"Reconciled PENDING -> SUCCESS: {recipient} {units} "
                 f"{rationale} ({match['trx_id']})"
             )
             continue
 
-        issued_at_aware = ensure_timezone_aware(issued_at)
+        issued_at_aware = pending_row["issued_at"]
         scan_covers_row = (
             scan_complete
             and covered_since is not None
+            and covered_until is not None
             and issued_at_aware is not None
-            and covered_since <= issued_at_aware
+            and covered_since <= issued_at_aware - MATCH_CLOCK_SKEW
+            and covered_until >= issued_at_aware + CHAIN_MATCH_WINDOW
         )
-        if issued_at_aware is not None and issued_at_aware < stale_before and scan_covers_row:
+        if scan_covers_row:
             mark_issuance_failure(
                 conn,
                 log_id,
-                "No matching on-chain issuance within reconciliation window",
+                "No matching on-chain issuance within chain match window",
             )
             print(f"Reconciled PENDING -> FAILURE: {recipient} {units} {rationale}")
 
@@ -404,37 +497,52 @@ def reconcile_issuances(
         c for c in unmatched_chain if c["trx_id"] not in matched_trx_ids
     ]
     for chain_issue in unmatched_chain:
-        if (chain_issue["recipient"], token_decimal(chain_issue["units"])) in explained:
-            # Already explained by a confirmed pik / abc issuance whose trx_id was
-            # not captured in its log row — do not double-log it as out-of-band.
-            continue
-        conn.exec_driver_sql(
-            """
-            INSERT INTO token_issuance_log
-                (trx_id, recipient, units, status, error_message, rationale)
-            VALUES (%s, %s, %s, 'SUCCESS', %s, %s)
-            """,
-            (
-                chain_issue["trx_id"],
-                chain_issue["recipient"],
-                chain_issue["units"],
-                "out-of-band issuance recorded for audit",
-                RECONCILED_RATIONALE,
-            ),
+        uncaptured = _find_logged_success_for_chain_issue(
+            conn, chain_issue, trx_id=UNCAPTURED_TRX_PLACEHOLDER
         )
+        if uncaptured is not None:
+            complete_uncaptured_success(conn, uncaptured["id"], chain_issue["trx_id"])
+            print(
+                "Completed logged issuance from chain: "
+                f"{chain_issue['trx_id']} {chain_issue['recipient']} "
+                f"{chain_issue['units']} {uncaptured['rationale']}"
+            )
+            continue
+
+        explained = _find_logged_success_for_chain_issue(conn, chain_issue)
+        if explained is not None:
+            print(
+                "Recognized already-logged on-chain issuance: "
+                f"{chain_issue['trx_id']} {chain_issue['recipient']} "
+                f"{chain_issue['units']} {explained['rationale']}"
+            )
+            continue
+
         print(
-            "Audit-logged unexplained on-chain issuance: "
+            "Unexplained on-chain issuance without token_issuance_log origin: "
             f"{chain_issue['trx_id']} {chain_issue['recipient']} {chain_issue['units']}"
         )
 
 
 def reconcile_recent_issuances(db2, issuer):
-    scan = fetch_recent_chain_issuance_scan(issuer)
+    lookback = CHAIN_SCAN_LOOKBACK
+    with db2.engine.begin() as conn:
+        oldest_pending = conn.exec_driver_sql(
+            "SELECT MIN(issued_at) FROM token_issuance_log WHERE status = 'PENDING'"
+        ).scalar()
+    oldest_pending = ensure_timezone_aware(oldest_pending)
+    if oldest_pending is not None:
+        needed = utcnow() - oldest_pending + MATCH_CLOCK_SKEW + CHAIN_MATCH_WINDOW
+        if needed > lookback:
+            lookback = needed
+
+    scan = fetch_recent_chain_issuance_scan(issuer, lookback=lookback)
     with db2.engine.begin() as conn:
         reconcile_issuances(
             conn,
             scan["issuances"],
             covered_since=scan["covered_since"],
+            covered_until=scan["covered_until"],
             scan_complete=scan["complete"],
         )
 
@@ -445,18 +553,11 @@ def reconcile_recent_issuances(db2, issuer):
 
 
 def issue_balance_tokens(db2, issuer, rationale, balance_column):
-    """Immediate, self-healing issuance for per-member balances (pik / abc_pik).
+    """Write-ahead issuance for per-member balances (pik / abc_pik).
 
-    Each member with a positive balance is issued tokens; only on a confirmed
-    broadcast is the balance zeroed and a SUCCESS row logged. A failed broadcast
-    logs FAILURE and leaves the balance intact, so the member is simply retried on
-    the next cycle — a transient failure is temporary, never permanent.
-
-    This deliberately uses NO write-ahead PENDING guard: the guard exists for the
-    capped Management issuance (where a double issuance over-mints), but for a
-    per-member balance the safe failure mode is "retry next cycle", not "block the
-    member until reconciliation". See the write-ahead helper note above and
-    CHANGES.md.
+    Each member with a positive balance gets a committed PENDING intent before
+    broadcast. If the process dies after broadcast and before SUCCESS is recorded,
+    reconciliation completes the same row from chain history.
     """
     with db2.engine.begin() as conn:
         balance_rows = conn.exec_driver_sql(
@@ -473,41 +574,43 @@ def issue_balance_tokens(db2, issuer, rationale, balance_column):
             print(f"Sleeping for {BATCH_SLEEP_TIME} seconds...")
             time.sleep(BATCH_SLEEP_TIME)
 
-        # 1. broadcast (the only step that cannot be rolled back)
+        with db2.engine.begin() as conn:
+            pending_count = conn.exec_driver_sql(
+                """
+                SELECT COUNT(*) FROM token_issuance_log
+                WHERE status = 'PENDING' AND recipient = %s AND rationale = %s
+                """,
+                (member_name, rationale),
+            ).scalar()
+            if pending_count:
+                print(
+                    f"Skipping {rationale} issuance to {member_name}: "
+                    "existing PENDING intent"
+                )
+                continue
+            log_id = insert_pending_issuance(conn, member_name, amount, rationale)
+
         print(f"Issuing {amount} HSBIDAO ({rationale}) to {member_name}")
         try:
             tx = issuer.issue(member_name, float(amount))
-            trx_id = tx.get("trx_id") or tx.get("transaction_id") or "N/A"
+            trx_id = issue_trx_id(tx)
             print("Issued:", tx)
         except Exception as e:
             print(f"Failed to issue to {member_name}: {e}")
-            # Leave the balance intact for retry next cycle; just record the failure.
             with db2.engine.begin() as conn:
-                log_issuance(
-                    conn,
-                    trx_id="N/A",
-                    recipient=member_name,
-                    units=amount,
-                    status="FAILURE",
-                    rationale=rationale,
-                    error_message=str(e),
-                )
+                record_pending_error(conn, log_id, str(e))
             continue
 
-        # 2. zero the issued balance and log SUCCESS in one transaction
         with db2.engine.begin() as conn:
             conn.exec_driver_sql(
-                f"UPDATE tokenholders SET {balance_column} = 0 WHERE member_name = %s",
-                (member_name,),
+                f"""
+                UPDATE tokenholders
+                SET {balance_column} = GREATEST({balance_column} - %s, 0)
+                WHERE member_name = %s
+                """,
+                (amount, member_name),
             )
-            log_issuance(
-                conn,
-                trx_id=trx_id,
-                recipient=member_name,
-                units=amount,
-                status="SUCCESS",
-                rationale=rationale,
-            )
+            mark_issuance_success(conn, log_id, trx_id)
 
 
 def issue_management_tokens(db2, issuer):
@@ -550,7 +653,7 @@ def issue_management_tokens(db2, issuer):
     print(f"Issuing {issue_amount} HSBIDAO Management tokens to {MANAGEMENT_RECIPIENT}")
     try:
         tx = issuer.issue(MANAGEMENT_RECIPIENT, float(issue_amount))
-        trx_id = tx.get("trx_id") or tx.get("transaction_id") or "N/A"
+        trx_id = issue_trx_id(tx)
         print("Issued:", tx)
     except Exception as e:
         print(f"Failed Management issuance to {MANAGEMENT_RECIPIENT}: {e}")

--- a/sql/20260602_virtual_tokens.sql
+++ b/sql/20260602_virtual_tokens.sql
@@ -44,6 +44,29 @@ BEGIN
         ALTER TABLE token_issuance_log
             MODIFY COLUMN status enum('SUCCESS','FAILURE','PENDING') NOT NULL;
     END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'token_issuance_log'
+          AND COLUMN_NAME = 'source_trx_id'
+    ) THEN
+        ALTER TABLE token_issuance_log
+            ADD COLUMN source_trx_id varchar(100) DEFAULT NULL
+            AFTER rationale;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'token_issuance_log'
+          AND INDEX_NAME = 'idx_source_trx_id'
+    ) THEN
+        ALTER TABLE token_issuance_log
+            ADD INDEX idx_source_trx_id (source_trx_id);
+    END IF;
 END;;
 
 CALL migrate_virtual_tokens();;

--- a/sql/PROD_RUNBOOK_virtual_tokens.sql
+++ b/sql/PROD_RUNBOOK_virtual_tokens.sql
@@ -18,6 +18,17 @@
 USE `sbi`;
 
 -- -----------------------------------------------------------------------------
+-- PROD STATE MEASURED 2026-07-28 (re-run the pre-checks; do not trust this blind)
+--   step 1 virtual_tokens column ................. ALREADY APPLIED — skip
+--   step 2 tokens generated expression ........... ALREADY APPLIED — skip
+--   step 3 status enum includes 'PENDING' ........ ALREADY APPLIED — skip
+--   step 4 source_trx_id column + index .......... NOT APPLIED — run this
+-- i.e. prod is post-#138 / pre-#139. Step 4 is the only DDL required, and it must
+-- land BEFORE the code deploy (insert_pending_issuance writes source_trx_id on
+-- every issuance) and BEFORE the LEGACY CLEANUP backfill at the bottom.
+-- -----------------------------------------------------------------------------
+
+-- -----------------------------------------------------------------------------
 -- PRE-CHECKS — run these first and read the output before changing anything.
 -- -----------------------------------------------------------------------------
 
@@ -54,6 +65,18 @@ WHERE TABLE_SCHEMA = 'sbi'
 -- -----------------------------------------------------------------------------
 -- APPLY — run only the statements whose pre-check showed the OLD state.
 -- Each is safe to skip if the pre-check already shows the new state.
+--
+-- STOP THE PIPELINE FIRST:
+--     systemctl stop sbirunner
+-- sbirunner.service is Restart=always and loops continuously, and
+-- hsbi_token_snapshot writes token_issuance_log every cycle. DDL on that table
+-- takes a metadata lock the running job will block on, and the LEGACY CLEANUP
+-- below (UPDATE trx_id / DELETE) races a live reconciliation pass that is reading
+-- and updating the same rows. Restart only after the post-checks pass.
+--
+-- Note on ADD COLUMN: MariaDB applies it instantly only when the new column lands
+-- at the end of the row. Confirm `rationale` is currently the last column
+-- (ORDINAL_POSITION) — if it is not, `AFTER rationale` rebuilds the whole table.
 -- -----------------------------------------------------------------------------
 
 -- 1. Add the virtual_tokens column (positioned after LP_tokens for readability).
@@ -127,37 +150,111 @@ WHERE mgmt.member_name = 'josephsavage';
 -- -----------------------------------------------------------------------------
 -- 'reconciled' was never a valid rationale (valid: pik, Pending Balance
 -- Conversion, Unit Conversion, Management). PR #138's reconciliation inserted
--- these as duplicate rows for issuances whose real log row had trx_id='N/A';
--- the current code updates the original row in place instead. Existing rows do
--- not affect the Management cap (which sums rationale='Management' only), but
--- they pollute the audit trail.
+-- these as duplicate SUCCESS rows for chain issues it could not tie back to a log
+-- row; the current code updates the original row in place instead. They do NOT
+-- affect the Management cap (which sums rationale='Management' only), but any
+-- report summing SUCCESS units counts the same issuance twice.
 --
--- Review first: pair each 'reconciled' row with its likely original (same
--- recipient + units, SUCCESS, uncaptured trx_id, within the match window).
+-- WHY THESE ARE ALL 'Unit Conversion': that path logged the originating *transfer*
+-- hash in trx_id, never the Hive Engine issue hash, so its chain op never matched
+-- the trx_id check and fell through to the orphan branch on every pass. pik /
+-- Pending Balance Conversion / Management all log the real issue trx_id and were
+-- never affected.
+--
+-- NOTE ON TIMESTAMPS: PR #138's INSERT omitted issued_at, so it defaulted to
+-- current_timestamp() — the RECONCILIATION-PASS time, not the issuance time. Do
+-- not pair on a narrow window around it, and do not treat r.issued_at as when the
+-- tokens were minted. The original always precedes the duplicate.
+
+-- 1. Measure the overstatement (record this before changing anything).
+SELECT rationale, status, COUNT(*) AS row_count, SUM(units) AS units,
+       MIN(issued_at) AS first_seen, MAX(issued_at) AS last_seen
+FROM token_issuance_log
+GROUP BY rationale, status
+ORDER BY units DESC;
+
+-- 2. Backfill source_trx_id for legacy Unit Conversion rows. MUST run BEFORE
+--    step 4: those rows hold the originating transfer hash in trx_id, and step 4
+--    overwrites it with the issue hash. This also makes
+--    hivesbi.issuance_log.has_issuance_for_source effective for historic
+--    transfers, which otherwise match nothing (source_trx_id IS NULL).
+UPDATE token_issuance_log
+SET source_trx_id = trx_id
+WHERE rationale = 'Unit Conversion'
+  AND source_trx_id IS NULL;
+
+-- 3. Pair each 'reconciled' row with its original (same recipient + units, an
+--    earlier SUCCESS row under a real rationale). Review the output before acting.
 SELECT
-    r.id  AS reconciled_id,
-    r.trx_id,
+    r.id AS dup_id,
+    r.trx_id AS chain_trx,
     r.recipient,
     r.units,
-    r.issued_at,
-    s.id  AS original_id,
+    r.issued_at AS reconciled_at,
+    s.id AS original_id,
     s.rationale AS original_rationale,
-    s.issued_at AS original_issued_at
+    s.trx_id AS original_trx,
+    s.issued_at AS original_issued_at,
+    TIMESTAMPDIFF(MINUTE, s.issued_at, r.issued_at) AS gap_minutes
 FROM token_issuance_log r
 LEFT JOIN token_issuance_log s
-       ON s.recipient = r.recipient
-      AND s.units = r.units
-      AND s.status = 'SUCCESS'
-      AND s.trx_id = 'N/A'
-      AND s.issued_at BETWEEN r.issued_at - INTERVAL 35 MINUTE
-                          AND r.issued_at + INTERVAL 35 MINUTE
+       ON  s.id        <> r.id
+       AND s.recipient  = r.recipient
+       AND s.units      = r.units
+       AND s.status     = 'SUCCESS'
+       AND s.rationale <> 'reconciled'
+       AND s.issued_at <= r.issued_at
+       AND s.issued_at >= r.issued_at - INTERVAL 12 HOUR
 WHERE r.rationale = 'reconciled'
-ORDER BY r.issued_at;
+ORDER BY r.issued_at, gap_minutes;
 
--- For each confidently paired row: move the chain trx_id onto the original row,
--- then delete the duplicate (run per id after reviewing the SELECT above):
---   UPDATE token_issuance_log SET trx_id = '<r.trx_id>' WHERE id = <original_id>;
---   DELETE FROM token_issuance_log WHERE id = <reconciled_id>;
+-- 3b. Ambiguous rows: more than one candidate original. Resolve these by hand
+--     (take the nearest in time) before running the deletes.
+SELECT r.id AS dup_id, r.recipient, r.units, r.issued_at,
+       COUNT(s.id) AS candidate_originals
+FROM token_issuance_log r
+JOIN token_issuance_log s
+       ON  s.id        <> r.id
+       AND s.recipient  = r.recipient
+       AND s.units      = r.units
+       AND s.status     = 'SUCCESS'
+       AND s.rationale <> 'reconciled'
+       AND s.issued_at <= r.issued_at
+       AND s.issued_at >= r.issued_at - INTERVAL 12 HOUR
+WHERE r.rationale = 'reconciled'
+GROUP BY r.id, r.recipient, r.units, r.issued_at
+HAVING COUNT(s.id) > 1;
+
+-- 4. For each confirmed pair: move the real chain trx_id onto the original row,
+--    then delete the duplicate (run per id after reviewing step 3):
+--      UPDATE token_issuance_log SET trx_id = '<chain_trx>' WHERE id = <original_id>;
+--      DELETE FROM token_issuance_log WHERE id = <dup_id>;
 --
--- A 'reconciled' row with NO pair is the only record of a genuine out-of-band
--- mint — investigate it before deleting anything.
+-- A 'reconciled' row with no pair at 12h is NOT automatically a genuine
+-- out-of-band mint — widen to 48h first. Only a row that stays unpaired after
+-- that is worth investigating as a real unlogged issuance.
+
+-- 5. Verify: expect zero 'reconciled' rows, and SUCCESS units down by exactly the
+--    amount recorded in step 1.
+SELECT rationale, status, COUNT(*) AS row_count, SUM(units) AS units
+FROM token_issuance_log
+GROUP BY rationale, status
+ORDER BY units DESC;
+
+-- -----------------------------------------------------------------------------
+-- OTHER NON-CANONICAL RATIONALES — decide, do not delete blindly
+-- -----------------------------------------------------------------------------
+-- Two more values exist that are not in the valid set. Neither is a duplicate, so
+-- neither is covered by the cleanup above:
+--   rationale='FAILURE' — status FAILURE, a legacy path that wrote the status into
+--     the rationale column. Never summed (status is FAILURE), but it shows up as a
+--     bogus category in any report that GROUPs BY rationale. Safe to relabel.
+--   rationale='Reissue' — status SUCCESS, a one-off manual event. This is REAL
+--     issuance: relabel or document it, never delete it.
+SELECT rationale, status, COUNT(*) AS row_count, SUM(units) AS units,
+       MIN(issued_at) AS first_seen, MAX(issued_at) AS last_seen
+FROM token_issuance_log
+WHERE rationale NOT IN ('pik', 'Pending Balance Conversion', 'Unit Conversion',
+                        'Management')
+   OR rationale IS NULL
+GROUP BY rationale, status;

--- a/sql/PROD_RUNBOOK_virtual_tokens.sql
+++ b/sql/PROD_RUNBOOK_virtual_tokens.sql
@@ -21,6 +21,15 @@ USE `sbi`;
 -- PRE-CHECKS — run these first and read the output before changing anything.
 -- -----------------------------------------------------------------------------
 
+-- 0. Time zone sanity. Issuance intent timestamps (token_issuance_log.issued_at)
+--    are written by the app as UTC wall time and matched against chain (UTC)
+--    timestamps within a ±minutes window; issued_at is a TIMESTAMP column, so a
+--    non-UTC session/system time zone silently shifts every stored instant and
+--    reconciliation windows never match (rows would eventually be failed and
+--    re-issued while the tokens were actually minted).
+--    Expect: SYSTEM / SYSTEM / UTC (or explicit '+00:00' / 'UTC').
+SELECT @@global.time_zone, @@session.time_zone, @@system_time_zone;
+
 -- Expect: virtual_tokens absent; tokens = `liquid_tokens` + `LP_tokens`
 SELECT COLUMN_NAME, COLUMN_TYPE, GENERATION_EXPRESSION
 FROM INFORMATION_SCHEMA.COLUMNS
@@ -100,7 +109,7 @@ WHERE `tokens` <> (`liquid_tokens` + `LP_tokens` + `virtual_tokens`);
 
 -- After deploying the code, run hsbi_check_delegation.py once to refresh the
 -- derived Management virtual token allocation. Verify josephsavage equals 10% of
--- all other virtual_tokens.
+-- all other virtual_tokens (plus 2x his own delegated HP, if he delegates).
 SELECT
     mgmt.member_name,
     mgmt.virtual_tokens AS josephsavage_virtual_tokens,
@@ -112,3 +121,43 @@ CROSS JOIN (
     WHERE member_name <> 'josephsavage'
 ) AS others
 WHERE mgmt.member_name = 'josephsavage';
+
+-- -----------------------------------------------------------------------------
+-- LEGACY CLEANUP — rationale='reconciled' rows (PR #138 artifact)
+-- -----------------------------------------------------------------------------
+-- 'reconciled' was never a valid rationale (valid: pik, Pending Balance
+-- Conversion, Unit Conversion, Management). PR #138's reconciliation inserted
+-- these as duplicate rows for issuances whose real log row had trx_id='N/A';
+-- the current code updates the original row in place instead. Existing rows do
+-- not affect the Management cap (which sums rationale='Management' only), but
+-- they pollute the audit trail.
+--
+-- Review first: pair each 'reconciled' row with its likely original (same
+-- recipient + units, SUCCESS, uncaptured trx_id, within the match window).
+SELECT
+    r.id  AS reconciled_id,
+    r.trx_id,
+    r.recipient,
+    r.units,
+    r.issued_at,
+    s.id  AS original_id,
+    s.rationale AS original_rationale,
+    s.issued_at AS original_issued_at
+FROM token_issuance_log r
+LEFT JOIN token_issuance_log s
+       ON s.recipient = r.recipient
+      AND s.units = r.units
+      AND s.status = 'SUCCESS'
+      AND s.trx_id = 'N/A'
+      AND s.issued_at BETWEEN r.issued_at - INTERVAL 35 MINUTE
+                          AND r.issued_at + INTERVAL 35 MINUTE
+WHERE r.rationale = 'reconciled'
+ORDER BY r.issued_at;
+
+-- For each confidently paired row: move the chain trx_id onto the original row,
+-- then delete the duplicate (run per id after reviewing the SELECT above):
+--   UPDATE token_issuance_log SET trx_id = '<r.trx_id>' WHERE id = <original_id>;
+--   DELETE FROM token_issuance_log WHERE id = <reconciled_id>;
+--
+-- A 'reconciled' row with NO pair is the only record of a genuine out-of-band
+-- mint — investigate it before deleting anything.

--- a/sql/PROD_RUNBOOK_virtual_tokens.sql
+++ b/sql/PROD_RUNBOOK_virtual_tokens.sql
@@ -6,11 +6,13 @@
 -- run sql/20260602_virtual_tokens.sql against prod — that procedure is for dev.
 --
 -- Target DB: sbi   (mysql on the prod VPS)
--- All three statements are additive and non-destructive (no data rewrite):
+-- All statements are additive/non-destructive except the generated-column metadata
+-- update:
 --   1. ADD COLUMN virtual_tokens (defaults 0.000 for every existing row)
 --   2. MODIFY the VIRTUAL generated `tokens` column to add virtual_tokens
 --      (metadata-only; VIRTUAL columns store no data)
 --   3. MODIFY token_issuance_log.status enum to add 'PENDING'
+--   4. ADD COLUMN token_issuance_log.source_trx_id + index
 -- =============================================================================
 
 USE `sbi`;
@@ -26,12 +28,19 @@ WHERE TABLE_SCHEMA = 'sbi'
   AND TABLE_NAME = 'tokenholders'
   AND COLUMN_NAME IN ('liquid_tokens', 'LP_tokens', 'virtual_tokens', 'tokens');
 
--- Expect: enum('SUCCESS','FAILURE')
-SELECT COLUMN_TYPE
+-- Expect: status present; source_trx_id may be absent before step 4.
+SELECT COLUMN_NAME, COLUMN_TYPE
 FROM INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_SCHEMA = 'sbi'
   AND TABLE_NAME = 'token_issuance_log'
-  AND COLUMN_NAME = 'status';
+  AND COLUMN_NAME IN ('status', 'source_trx_id');
+
+-- Expect: idx_source_trx_id absent before step 4.
+SELECT INDEX_NAME, COLUMN_NAME
+FROM INFORMATION_SCHEMA.STATISTICS
+WHERE TABLE_SCHEMA = 'sbi'
+  AND TABLE_NAME = 'token_issuance_log'
+  AND INDEX_NAME = 'idx_source_trx_id';
 
 -- -----------------------------------------------------------------------------
 -- APPLY — run only the statements whose pre-check showed the OLD state.
@@ -51,6 +60,13 @@ ALTER TABLE `tokenholders`
 ALTER TABLE `token_issuance_log`
     MODIFY COLUMN `status` enum('SUCCESS','FAILURE','PENDING') NOT NULL;
 
+-- 4. Add origin/source transaction storage for token issuance rows.
+ALTER TABLE `token_issuance_log`
+    ADD COLUMN `source_trx_id` varchar(100) DEFAULT NULL AFTER `rationale`;
+
+ALTER TABLE `token_issuance_log`
+    ADD INDEX `idx_source_trx_id` (`source_trx_id`);
+
 -- -----------------------------------------------------------------------------
 -- POST-CHECKS — confirm the new state.
 -- -----------------------------------------------------------------------------
@@ -62,15 +78,37 @@ WHERE TABLE_SCHEMA = 'sbi'
   AND TABLE_NAME = 'tokenholders'
   AND COLUMN_NAME IN ('virtual_tokens', 'tokens');
 
--- Expect: enum('SUCCESS','FAILURE','PENDING')
-SELECT COLUMN_TYPE
+-- Expect: status includes PENDING and source_trx_id is present.
+SELECT COLUMN_NAME, COLUMN_TYPE
 FROM INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_SCHEMA = 'sbi'
   AND TABLE_NAME = 'token_issuance_log'
-  AND COLUMN_NAME = 'status';
+  AND COLUMN_NAME IN ('status', 'source_trx_id');
+
+-- Expect: idx_source_trx_id present.
+SELECT INDEX_NAME, COLUMN_NAME
+FROM INFORMATION_SCHEMA.STATISTICS
+WHERE TABLE_SCHEMA = 'sbi'
+  AND TABLE_NAME = 'token_issuance_log'
+  AND INDEX_NAME = 'idx_source_trx_id';
 
 -- Sanity: tokens should equal liquid_tokens + LP_tokens for every row right after
 -- step 1/2 (virtual_tokens defaults to 0 until hsbi_check_delegation populates it).
 SELECT COUNT(*) AS rows_where_tokens_mismatch
 FROM `tokenholders`
 WHERE `tokens` <> (`liquid_tokens` + `LP_tokens` + `virtual_tokens`);
+
+-- After deploying the code, run hsbi_check_delegation.py once to refresh the
+-- derived Management virtual token allocation. Verify josephsavage equals 10% of
+-- all other virtual_tokens.
+SELECT
+    mgmt.member_name,
+    mgmt.virtual_tokens AS josephsavage_virtual_tokens,
+    ROUND(others.non_management_virtual_tokens * 0.10, 3) AS expected_virtual_tokens
+FROM `tokenholders` AS mgmt
+CROSS JOIN (
+    SELECT COALESCE(SUM(virtual_tokens), 0) AS non_management_virtual_tokens
+    FROM `tokenholders`
+    WHERE member_name <> 'josephsavage'
+) AS others
+WHERE mgmt.member_name = 'josephsavage';

--- a/tests/test_virtual_tokens.py
+++ b/tests/test_virtual_tokens.py
@@ -1,15 +1,14 @@
-"""Tests for delegation virtual_tokens, per-member (pik / abc_pik) issuance, the
-Management 10% write-ahead issuance, and chain-confirm reconciliation.
+"""Tests for delegation virtual_tokens, write-ahead token issuance intents,
+Management 10% issuance, and chain-confirm reconciliation.
 
 The pure-logic tests run anywhere. The DB-level tests connect to the local docker
 MariaDB (the `sbi` database via config.json `databaseConnector2`) and run inside a
 transaction that is rolled back, so they leave no residue. They skip automatically
 when the database is unreachable (e.g. running on the host without the container).
 
-Design note (PR #138 review): per-member pik / abc_pik issuance is immediate and
-self-healing — a failed broadcast leaves the balance for retry next cycle and never
-creates a PENDING row. Only the capped Management issuance uses the write-ahead
-PENDING protocol, so reconciliation is rationale-scoped to Management.
+Design note: every token issuance path creates a durable PENDING intent before
+broadcast. Reconciliation uses chain timestamps to complete or fail those intents;
+it never invents rationale from chain history.
 """
 
 import json
@@ -20,8 +19,15 @@ from unittest.mock import patch
 
 from hsbi_check_delegation import (
     apply_active_delegations,
+    calculate_management_virtual_tokens,
     calculate_virtual_tokens,
     clear_delegation_trx,
+    refresh_management_virtual_tokens,
+)
+from hivesbi.parse_hist_op import (
+    UNIT_CONVERSION_RATIONALE,
+    _insert_pending_token_issuance,
+    _mark_token_issuance_success,
 )
 from hsbi_token_snapshot import (
     TOKEN_PRECISION,
@@ -112,6 +118,12 @@ class PureLogicTests(unittest.TestCase):
         # No integer rounding: 0.001 HP delegated -> 0.002 virtual tokens.
         self.assertEqual(calculate_virtual_tokens("0.001"), Decimal("0.002"))
         self.assertEqual(calculate_virtual_tokens("123.4567"), Decimal("246.913"))
+
+    def test_management_virtual_tokens_are_ten_percent_of_others(self):
+        self.assertEqual(
+            calculate_management_virtual_tokens(Decimal("1000.000")),
+            Decimal("100.000"),
+        )
 
     def test_management_formula_floors_to_three_decimals(self):
         # 0.10 * 1000 / 0.90 = 111.111... -> floored to 111.111
@@ -290,9 +302,46 @@ class DelegationAccrualTests(DBTestCase):
         ).fetchone()
         self.assertEqual(Decimal(str(vt[0])), Decimal("12.345"))
 
+    def test_refresh_management_virtual_tokens_excludes_management(self):
+        self.x("UPDATE tokenholders SET virtual_tokens = 0")
+        self._insert_holder("zz_vt_other_a", virtual=Decimal("400.000"))
+        self._insert_holder("zz_vt_other_b", virtual=Decimal("600.000"))
+        self.x(
+            """
+            INSERT INTO tokenholders (member_name, virtual_tokens)
+            VALUES (%s, %s)
+            ON DUPLICATE KEY UPDATE virtual_tokens = VALUES(virtual_tokens)
+            """,
+            (T_MGMT, Decimal("999.000")),
+        )
+
+        refreshed = refresh_management_virtual_tokens(self.conn)
+
+        self.assertEqual(refreshed, Decimal("100.000"))
+        row = self.x(
+            "SELECT virtual_tokens FROM tokenholders WHERE member_name = %s",
+            (T_MGMT,),
+        ).fetchone()
+        self.assertEqual(Decimal(str(row[0])), Decimal("100.000"))
+
+    def test_refresh_management_virtual_tokens_upserts_missing_management_row(self):
+        self.x("UPDATE tokenholders SET virtual_tokens = 0")
+        self.x("DELETE FROM tokenholders WHERE member_name = %s", (T_MGMT,))
+        self._insert_holder("zz_vt_other_c", virtual=Decimal("1000.000"))
+
+        refreshed = refresh_management_virtual_tokens(self.conn)
+
+        self.assertEqual(refreshed, Decimal("100.000"))
+        row = self.x(
+            "SELECT virtual_tokens FROM tokenholders WHERE member_name = %s",
+            (T_MGMT,),
+        ).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(Decimal(str(row[0])), Decimal("100.000"))
+
 
 class ImmediateBalanceIssuanceTests(DBTestCase):
-    """pik / abc_pik issuance is immediate and self-healing — no PENDING guard."""
+    """pik / abc_pik issuance uses write-ahead PENDING intents."""
 
     def test_success_zeroes_balance_and_logs_success(self):
         self._insert_holder(T_PIK, pik=Decimal("5.000"))
@@ -312,9 +361,7 @@ class ImmediateBalanceIssuanceTests(DBTestCase):
         self.assertEqual(row[0], "SUCCESS")
         self.assertEqual(row[2], "pik")
 
-    def test_failure_keeps_balance_for_retry_and_creates_no_pending(self):
-        # The whole point of reverting the write-ahead pik path: a transient failure
-        # must be temporary (retried next cycle), never a permanent PENDING block.
+    def test_failure_keeps_balance_and_leaves_pending_for_reconciliation(self):
         self._insert_holder(T_PIK, pik=Decimal("5.000"))
         issuer = FakeIssuer(fail=True)
         issue_balance_tokens(FakeDB2(self.conn), issuer, "pik", "pik")
@@ -325,18 +372,28 @@ class ImmediateBalanceIssuanceTests(DBTestCase):
         self.assertEqual(Decimal(str(pik)), Decimal("5.000"))  # intact -> retried
 
         last = self.x(
-            "SELECT status FROM token_issuance_log WHERE recipient = %s "
+            "SELECT status, error_message FROM token_issuance_log WHERE recipient = %s "
             "AND rationale = 'pik' ORDER BY id DESC LIMIT 1",
             (T_PIK,),
         ).fetchone()
-        self.assertEqual(last[0], "FAILURE")
+        self.assertEqual(last[0], "PENDING")
+        self.assertIn("simulated broadcast failure", last[1])
 
         pending = self.x(
             "SELECT COUNT(*) FROM token_issuance_log WHERE recipient = %s "
             "AND status = 'PENDING'",
             (T_PIK,),
         ).fetchone()[0]
-        self.assertEqual(int(pending), 0)
+        self.assertEqual(int(pending), 1)
+
+    def test_existing_pending_blocks_duplicate_balance_issuance(self):
+        self._insert_holder(T_PIK, pik=Decimal("5.000"))
+        insert_pending_issuance(self.conn, T_PIK, Decimal("5.000"), "pik")
+        issuer = FakeIssuer(trx_id="chain_should_not_issue")
+
+        issue_balance_tokens(FakeDB2(self.conn), issuer, "pik", "pik")
+
+        self.assertEqual(issuer.calls, [])
 
     def test_abc_pik_uses_its_own_column_and_rationale(self):
         self._insert_holder(T_PIK, abc_pik=Decimal("3.000"))
@@ -394,6 +451,70 @@ class ManagementIssuanceTests(DBTestCase):
         self.assertEqual(after - before, Decimal("7.000"))
 
 
+class UnitConversionIssuanceTests(DBTestCase):
+    def test_unit_conversion_separates_source_and_issue_trx_ids(self):
+        source_trx = "6fda651869153df5fefb8080c1cc985ee155261b"
+        issue_trx = "af4cedd8f982efd512e890912b067a6403e891b7"
+        log_id = _insert_pending_token_issuance(
+            self.conn,
+            T_PIK,
+            Decimal("10.000"),
+            UNIT_CONVERSION_RATIONALE,
+            source_trx_id=source_trx,
+        )
+
+        _mark_token_issuance_success(self.conn, log_id, issue_trx)
+
+        row = self.x(
+            """
+            SELECT status, trx_id, source_trx_id, rationale
+            FROM token_issuance_log
+            WHERE id = %s
+            """,
+            (log_id,),
+        ).fetchone()
+        self.assertEqual(row[0], "SUCCESS")
+        self.assertEqual(row[1], issue_trx)
+        self.assertEqual(row[2], source_trx)
+        self.assertEqual(row[3], UNIT_CONVERSION_RATIONALE)
+
+    def test_unit_conversion_issue_trx_does_not_reconcile_duplicate(self):
+        source_trx = "6fda651869153df5fefb8080c1cc985ee155261b"
+        issue_trx = "af4cedd8f982efd512e890912b067a6403e891b7"
+        now = datetime.now(timezone.utc)
+        log_id = _insert_pending_token_issuance(
+            self.conn,
+            T_PIK,
+            Decimal("10.000"),
+            UNIT_CONVERSION_RATIONALE,
+            source_trx_id=source_trx,
+        )
+        _mark_token_issuance_success(self.conn, log_id, issue_trx)
+
+        reconcile_issuances(
+            self.conn,
+            [
+                {
+                    "trx_id": issue_trx,
+                    "recipient": T_PIK,
+                    "units": Decimal("10.000"),
+                    "timestamp": now,
+                }
+            ],
+            now=now,
+        )
+
+        duplicate_count = self.x(
+            "SELECT COUNT(*) FROM token_issuance_log WHERE trx_id = %s",
+            (issue_trx,),
+        ).fetchone()[0]
+        reconciled_count = self.x(
+            "SELECT COUNT(*) FROM token_issuance_log WHERE rationale = 'reconciled'"
+        ).fetchone()[0]
+        self.assertEqual(int(duplicate_count), 1)
+        self.assertEqual(int(reconciled_count), 0)
+
+
 class SyncTokenholdersTests(DBTestCase):
     def test_sync_zeroes_then_upserts_liquid_from_chain(self):
         self._insert_holder(T_HOLDER, liquid=Decimal("1.000"))
@@ -411,12 +532,20 @@ class SyncTokenholdersTests(DBTestCase):
 
 class ReconciliationTests(DBTestCase):
     def test_pending_management_confirmed_keeps_rationale(self):
+        now = datetime.now(timezone.utc)
         log_id = insert_pending_issuance(
-            self.conn, T_MGMT, Decimal("12.345"), "Management"
+            self.conn, T_MGMT, Decimal("12.345"), "Management", issued_at=now
         )
         reconcile_issuances(
             self.conn,
-            [{"trx_id": "chain_mgmt_1", "recipient": T_MGMT, "units": Decimal("12.345")}],
+            [
+                {
+                    "trx_id": "chain_mgmt_1",
+                    "recipient": T_MGMT,
+                    "units": Decimal("12.345"),
+                    "timestamp": now + timedelta(seconds=30),
+                }
+            ],
         )
         row = self.x(
             "SELECT status, trx_id, rationale FROM token_issuance_log WHERE id = %s",
@@ -431,11 +560,23 @@ class ReconciliationTests(DBTestCase):
         # same amount in one cycle. The pik issuance is already logged SUCCESS with
         # its real trx_id, so it is excluded; the Management PENDING must match the
         # *Management* chain op, never the pik one.
-        log_issuance(
-            self.conn, "chain_pik_real", T_MGMT, Decimal("5.000"), "SUCCESS", "pik"
-        )
-        mgmt_id = insert_pending_issuance(self.conn, T_MGMT, Decimal("5.000"), "Management")
         now = datetime.now(timezone.utc)
+        log_issuance(
+            self.conn,
+            "chain_pik_real",
+            T_MGMT,
+            Decimal("5.000"),
+            "SUCCESS",
+            "pik",
+            issued_at=now - timedelta(minutes=2),
+        )
+        mgmt_id = insert_pending_issuance(
+            self.conn,
+            T_MGMT,
+            Decimal("5.000"),
+            "Management",
+            issued_at=now - timedelta(minutes=1),
+        )
         chain = [
             {
                 "trx_id": "chain_pik_real",
@@ -465,19 +606,37 @@ class ReconciliationTests(DBTestCase):
         ).fetchone()[0]
         self.assertEqual(int(orphans), 0)
 
-    def test_unlogged_pik_chain_issue_suppressed_from_orphans(self):
+    def test_uncaptured_pik_chain_issue_updates_existing_log(self):
         # A pik issuance whose on-chain trx_id was not captured (logged 'N/A') must
         # not be double-logged as an out-of-band 'reconciled' issuance.
-        log_issuance(self.conn, "N/A", T_PIK, Decimal("3.000"), "SUCCESS", "pik")
+        now = datetime.now(timezone.utc)
+        log_issuance(
+            self.conn,
+            "N/A",
+            T_PIK,
+            Decimal("3.000"),
+            "SUCCESS",
+            "pik",
+            issued_at=now,
+        )
         chain = [
-            {"trx_id": "chain_pik_uncaptured", "recipient": T_PIK, "units": Decimal("3.000")}
+            {
+                "trx_id": "chain_pik_uncaptured",
+                "recipient": T_PIK,
+                "units": Decimal("3.000"),
+                "timestamp": now + timedelta(seconds=5),
+            }
         ]
-        reconcile_issuances(self.conn, chain, now=datetime.now(timezone.utc))
-        orphan = self.x(
-            "SELECT COUNT(*) FROM token_issuance_log WHERE trx_id = %s",
+        reconcile_issuances(self.conn, chain, now=now)
+        updated = self.x(
+            "SELECT COUNT(*) FROM token_issuance_log WHERE trx_id = %s AND rationale = 'pik'",
             ("chain_pik_uncaptured",),
         ).fetchone()[0]
-        self.assertEqual(int(orphan), 0)
+        self.assertEqual(int(updated), 1)
+        reconciled = self.x(
+            "SELECT COUNT(*) FROM token_issuance_log WHERE rationale = 'reconciled'"
+        ).fetchone()[0]
+        self.assertEqual(int(reconciled), 0)
 
     def test_stale_unmatched_pending_stays_pending_without_covered_scan(self):
         stale_ts = datetime.now(timezone.utc) - timedelta(hours=6)
@@ -512,6 +671,7 @@ class ReconciliationTests(DBTestCase):
             [],
             now=datetime.now(timezone.utc),
             covered_since=stale_ts - timedelta(minutes=1),
+            covered_until=stale_ts + timedelta(minutes=31),
             scan_complete=True,
         )
         status = self.x(
@@ -527,21 +687,76 @@ class ReconciliationTests(DBTestCase):
         ).fetchone()[0]
         self.assertEqual(status, "PENDING")
 
-    def test_orphan_chain_issue_logged_as_reconciled_only(self):
+    def test_orphan_chain_issue_reported_not_inserted(self):
         orphan = {
             "trx_id": "chain_orphan_1",
             "recipient": "zz_vt_orphan",
             "units": Decimal("1.000"),
+            "timestamp": datetime.now(timezone.utc),
         }
         reconcile_issuances(self.conn, [orphan])
-        row = self.x(
-            "SELECT status, rationale FROM token_issuance_log WHERE trx_id = %s",
+        count = self.x(
+            "SELECT COUNT(*) FROM token_issuance_log WHERE trx_id = %s",
             ("chain_orphan_1",),
+        ).fetchone()[0]
+        self.assertEqual(int(count), 0)
+
+    def test_reconciliation_completes_pik_pending_and_debits_balance(self):
+        now = datetime.now(timezone.utc)
+        self._insert_holder(T_PIK, pik=Decimal("5.000"))
+        log_id = insert_pending_issuance(
+            self.conn, T_PIK, Decimal("5.000"), "pik", issued_at=now
+        )
+
+        reconcile_issuances(
+            self.conn,
+            [
+                {
+                    "trx_id": "chain_pik_reconciled",
+                    "recipient": T_PIK,
+                    "units": Decimal("5.000"),
+                    "timestamp": now + timedelta(seconds=10),
+                }
+            ],
+            now=now,
+        )
+
+        row = self.x(
+            "SELECT status, trx_id FROM token_issuance_log WHERE id = %s",
+            (log_id,),
         ).fetchone()
-        self.assertIsNotNone(row)
+        pik = self.x(
+            "SELECT pik FROM tokenholders WHERE member_name = %s", (T_PIK,)
+        ).fetchone()[0]
         self.assertEqual(row[0], "SUCCESS")
-        # audit-only: never attributed to Management or any balance rationale
-        self.assertEqual(row[1], "reconciled")
+        self.assertEqual(row[1], "chain_pik_reconciled")
+        self.assertEqual(Decimal(str(pik)), Decimal("0.000"))
+
+    def test_reconciliation_uses_chain_timestamp_not_server_now(self):
+        intent_at = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+        log_id = insert_pending_issuance(
+            self.conn, T_MGMT, Decimal("5.000"), "Management", issued_at=intent_at
+        )
+
+        reconcile_issuances(
+            self.conn,
+            [
+                {
+                    "trx_id": "chain_timestamp_authority",
+                    "recipient": T_MGMT,
+                    "units": Decimal("5.000"),
+                    "timestamp": intent_at + timedelta(minutes=10),
+                }
+            ],
+            now=intent_at + timedelta(hours=8),
+        )
+
+        row = self.x(
+            "SELECT status, trx_id FROM token_issuance_log WHERE id = %s",
+            (log_id,),
+        ).fetchone()
+        self.assertEqual(row[0], "SUCCESS")
+        self.assertEqual(row[1], "chain_timestamp_authority")
 
     def test_nearest_timestamp_match_among_management_pending(self):
         # Two Management PENDING rows of the same amount; the chain op confirms the
@@ -590,6 +805,49 @@ class ReconciliationTests(DBTestCase):
         self.assertEqual(rows[0][1], "PENDING")
         self.assertEqual(rows[1][1], "SUCCESS")
         self.assertEqual(rows[1][2], "chain_nearest_1")
+
+    def test_ambiguous_equal_timestamp_distance_stays_pending(self):
+        now = datetime.now(timezone.utc)
+        first_id = self.x(
+            """
+            INSERT INTO token_issuance_log
+                (trx_id, recipient, units, status, error_message, rationale, issued_at)
+            VALUES ('PENDING', %s, %s, 'PENDING', NULL, 'Management', %s)
+            """,
+            (T_MGMT, Decimal("5.000"), now - timedelta(minutes=1)),
+        ).lastrowid
+        second_id = self.x(
+            """
+            INSERT INTO token_issuance_log
+                (trx_id, recipient, units, status, error_message, rationale, issued_at)
+            VALUES ('PENDING', %s, %s, 'PENDING', NULL, 'Management', %s)
+            """,
+            (T_MGMT, Decimal("5.000"), now + timedelta(minutes=1)),
+        ).lastrowid
+
+        reconcile_issuances(
+            self.conn,
+            [
+                {
+                    "trx_id": "chain_ambiguous_1",
+                    "recipient": T_MGMT,
+                    "units": Decimal("5.000"),
+                    "timestamp": now,
+                }
+            ],
+            now=now,
+        )
+
+        statuses = self.x(
+            """
+            SELECT status
+            FROM token_issuance_log
+            WHERE id IN (%s, %s)
+            ORDER BY id
+            """,
+            (first_id, second_id),
+        ).fetchall()
+        self.assertEqual([row[0] for row in statuses], ["PENDING", "PENDING"])
 
 
 if __name__ == "__main__":

--- a/tests/test_virtual_tokens.py
+++ b/tests/test_virtual_tokens.py
@@ -24,6 +24,7 @@ from hsbi_check_delegation import (
     clear_delegation_trx,
     refresh_management_virtual_tokens,
 )
+from hivesbi.issuance_log import has_issuance_for_source
 from hivesbi.parse_hist_op import (
     UNIT_CONVERSION_RATIONALE,
     _insert_pending_token_issuance,
@@ -33,6 +34,7 @@ from hsbi_token_snapshot import (
     TOKEN_PRECISION,
     _parse_engine_issue,
     calculate_management_issue_amount,
+    fetch_recent_chain_issuance_scan,
     insert_pending_issuance,
     issue_balance_tokens,
     issue_management_tokens,
@@ -113,6 +115,21 @@ class FakeDB2:
         self.engine = _FakeEngine(conn)
 
 
+class _FakeHistoryAccount:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def history_reverse(self, only_ops=None):
+        return iter(self._rows)
+
+
+class FakeChainIssuer:
+    """Issuer stand-in exposing a canned account history for scan tests."""
+
+    def __init__(self, rows):
+        self.hive_account = _FakeHistoryAccount(rows)
+
+
 class PureLogicTests(unittest.TestCase):
     def test_virtual_tokens_are_decimal_hp_times_two(self):
         # No integer rounding: 0.001 HP delegated -> 0.002 virtual tokens.
@@ -182,6 +199,28 @@ class PureLogicTests(unittest.TestCase):
             "op": ["custom_json", {"json": json.dumps({"contractName": "market"})}],
         }
         self.assertIsNone(_parse_engine_issue(row))
+
+    def test_scan_coverage_extends_to_scan_time_for_quiet_issuer(self):
+        # An issuer with no recent on-chain activity must still prove coverage up
+        # to roughly the scan time: history_reverse starts at the account head,
+        # so a successful fetch shows no newer ops exist. Old PENDING intents can
+        # then be failed without waiting for fresh issuer activity.
+        old_ts = datetime.now(timezone.utc) - timedelta(hours=48)
+        rows = [{"trx_id": "old_op", "timestamp": old_ts, "op": ["custom_json", {}]}]
+        scan = fetch_recent_chain_issuance_scan(FakeChainIssuer(rows))
+        self.assertTrue(scan["complete"])
+        self.assertGreater(
+            scan["covered_until"],
+            datetime.now(timezone.utc) - timedelta(minutes=10),
+        )
+
+    def test_scan_coverage_complete_for_empty_history(self):
+        scan = fetch_recent_chain_issuance_scan(FakeChainIssuer([]))
+        self.assertTrue(scan["complete"])
+        self.assertEqual(
+            scan["covered_since"], datetime.min.replace(tzinfo=timezone.utc)
+        )
+        self.assertIsNotNone(scan["covered_until"])
 
 
 @unittest.skipUnless(_DB_ENGINE is not None, _DB_SKIP_REASON)
@@ -338,6 +377,22 @@ class DelegationAccrualTests(DBTestCase):
         ).fetchone()
         self.assertIsNotNone(row)
         self.assertEqual(Decimal(str(row[0])), Decimal("100.000"))
+
+    def test_refresh_management_preserves_own_delegation_virtual(self):
+        # If the management account itself delegates HP, its delegation-derived
+        # virtual tokens are preserved on top of the derived 10% allocation
+        # rather than being overwritten by the refresh.
+        self.x("UPDATE tokenholders SET virtual_tokens = 0")
+        self._insert_holder("zz_vt_other_d", virtual=Decimal("1000.000"))
+
+        refreshed = refresh_management_virtual_tokens(self.conn, Decimal("50.000"))
+
+        self.assertEqual(refreshed, Decimal("150.000"))
+        row = self.x(
+            "SELECT virtual_tokens FROM tokenholders WHERE member_name = %s",
+            (T_MGMT,),
+        ).fetchone()
+        self.assertEqual(Decimal(str(row[0])), Decimal("150.000"))
 
 
 class ImmediateBalanceIssuanceTests(DBTestCase):
@@ -501,7 +556,6 @@ class UnitConversionIssuanceTests(DBTestCase):
                     "timestamp": now,
                 }
             ],
-            now=now,
         )
 
         duplicate_count = self.x(
@@ -513,6 +567,39 @@ class UnitConversionIssuanceTests(DBTestCase):
         ).fetchone()[0]
         self.assertEqual(int(duplicate_count), 1)
         self.assertEqual(int(reconciled_count), 0)
+
+    def test_source_trx_guard_blocks_pending_and_success_not_failure(self):
+        # A reprocessed transfer op must not mint the same source transaction
+        # twice: PENDING (in flight) and SUCCESS both block, a proven FAILURE
+        # leaves the retry path open.
+        source_trx = "zz_vt_source_guard_1"
+        self.assertFalse(
+            has_issuance_for_source(self.conn, source_trx, UNIT_CONVERSION_RATIONALE)
+        )
+
+        log_id = _insert_pending_token_issuance(
+            self.conn,
+            T_PIK,
+            Decimal("1.000"),
+            UNIT_CONVERSION_RATIONALE,
+            source_trx_id=source_trx,
+        )
+        self.assertTrue(
+            has_issuance_for_source(self.conn, source_trx, UNIT_CONVERSION_RATIONALE)
+        )
+
+        _mark_token_issuance_success(self.conn, log_id, "chain_src_guard_1")
+        self.assertTrue(
+            has_issuance_for_source(self.conn, source_trx, UNIT_CONVERSION_RATIONALE)
+        )
+
+        self.x(
+            "UPDATE token_issuance_log SET status = 'FAILURE' WHERE id = %s",
+            (log_id,),
+        )
+        self.assertFalse(
+            has_issuance_for_source(self.conn, source_trx, UNIT_CONVERSION_RATIONALE)
+        )
 
 
 class SyncTokenholdersTests(DBTestCase):
@@ -591,7 +678,7 @@ class ReconciliationTests(DBTestCase):
                 "timestamp": now - timedelta(minutes=1),
             },
         ]
-        reconcile_issuances(self.conn, chain, now=now)
+        reconcile_issuances(self.conn, chain)
 
         row = self.x(
             "SELECT status, trx_id FROM token_issuance_log WHERE id = %s", (mgmt_id,)
@@ -627,7 +714,7 @@ class ReconciliationTests(DBTestCase):
                 "timestamp": now + timedelta(seconds=5),
             }
         ]
-        reconcile_issuances(self.conn, chain, now=now)
+        reconcile_issuances(self.conn, chain)
         updated = self.x(
             "SELECT COUNT(*) FROM token_issuance_log WHERE trx_id = %s AND rationale = 'pik'",
             ("chain_pik_uncaptured",),
@@ -649,7 +736,7 @@ class ReconciliationTests(DBTestCase):
             (T_MGMT, Decimal("5.000"), stale_ts),
         )
         log_id = result.lastrowid
-        reconcile_issuances(self.conn, [], now=datetime.now(timezone.utc))
+        reconcile_issuances(self.conn, [])
         status = self.x(
             "SELECT status FROM token_issuance_log WHERE id = %s", (log_id,)
         ).fetchone()[0]
@@ -666,11 +753,12 @@ class ReconciliationTests(DBTestCase):
             (T_MGMT, Decimal("5.000"), stale_ts),
         )
         log_id = result.lastrowid
+        # Coverage must span the row's whole possible match window:
+        # [issued_at - MATCH_CLOCK_SKEW, issued_at + CHAIN_MATCH_WINDOW].
         reconcile_issuances(
             self.conn,
             [],
-            now=datetime.now(timezone.utc),
-            covered_since=stale_ts - timedelta(minutes=1),
+            covered_since=stale_ts - timedelta(minutes=6),
             covered_until=stale_ts + timedelta(minutes=31),
             scan_complete=True,
         )
@@ -681,7 +769,7 @@ class ReconciliationTests(DBTestCase):
 
     def test_recent_unmatched_pending_stays_pending(self):
         log_id = insert_pending_issuance(self.conn, T_MGMT, Decimal("5.000"), "Management")
-        reconcile_issuances(self.conn, [], now=datetime.now(timezone.utc))
+        reconcile_issuances(self.conn, [])
         status = self.x(
             "SELECT status FROM token_issuance_log WHERE id = %s", (log_id,)
         ).fetchone()[0]
@@ -718,7 +806,6 @@ class ReconciliationTests(DBTestCase):
                     "timestamp": now + timedelta(seconds=10),
                 }
             ],
-            now=now,
         )
 
         row = self.x(
@@ -733,6 +820,8 @@ class ReconciliationTests(DBTestCase):
         self.assertEqual(Decimal(str(pik)), Decimal("0.000"))
 
     def test_reconciliation_uses_chain_timestamp_not_server_now(self):
+        # An intent hours in the past still matches: only the chain timestamp
+        # relative to the intent timestamp matters, never the server clock.
         intent_at = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
         log_id = insert_pending_issuance(
             self.conn, T_MGMT, Decimal("5.000"), "Management", issued_at=intent_at
@@ -748,7 +837,6 @@ class ReconciliationTests(DBTestCase):
                     "timestamp": intent_at + timedelta(minutes=10),
                 }
             ],
-            now=intent_at + timedelta(hours=8),
         )
 
         row = self.x(
@@ -790,7 +878,6 @@ class ReconciliationTests(DBTestCase):
                     "timestamp": newer_ts + timedelta(seconds=30),
                 }
             ],
-            now=datetime.now(timezone.utc),
         )
 
         rows = self.x(
@@ -807,7 +894,10 @@ class ReconciliationTests(DBTestCase):
         self.assertEqual(rows[1][2], "chain_nearest_1")
 
     def test_ambiguous_equal_timestamp_distance_stays_pending(self):
-        now = datetime.now(timezone.utc)
+        # issued_at is a second-precision TIMESTAMP column, so the tie must be
+        # constructed on whole seconds to survive the DB round-trip. Even with
+        # full scan coverage, neither contested row may be resolved or failed.
+        now = datetime.now(timezone.utc).replace(microsecond=0)
         first_id = self.x(
             """
             INSERT INTO token_issuance_log
@@ -835,7 +925,9 @@ class ReconciliationTests(DBTestCase):
                     "timestamp": now,
                 }
             ],
-            now=now,
+            covered_since=now - timedelta(hours=1),
+            covered_until=now + timedelta(hours=1),
+            scan_complete=True,
         )
 
         statuses = self.x(
@@ -848,6 +940,51 @@ class ReconciliationTests(DBTestCase):
             (first_id, second_id),
         ).fetchall()
         self.assertEqual([row[0] for row in statuses], ["PENDING", "PENDING"])
+
+    def test_contested_pending_not_failed_then_resolves_next_pass(self):
+        # Chain issue X matches intent A (nearest); sibling intent B of the same
+        # recipient+units is contested by X, so a covering scan must NOT fail B
+        # this pass — X may actually be B's broadcast. Once A's SUCCESS records
+        # X's trx_id, the next pass excludes X, proves absence, and fails B, so
+        # a contested row never blocks its member forever.
+        base = datetime.now(timezone.utc).replace(microsecond=0)
+        a_ts = base - timedelta(hours=2)
+        b_ts = a_ts + timedelta(minutes=2)
+        a_id = insert_pending_issuance(
+            self.conn, T_MGMT, Decimal("5.000"), "Management", issued_at=a_ts
+        )
+        b_id = insert_pending_issuance(
+            self.conn, T_MGMT, Decimal("5.000"), "Management", issued_at=b_ts
+        )
+        chain = [
+            {
+                "trx_id": "chain_contested_1",
+                "recipient": T_MGMT,
+                "units": Decimal("5.000"),
+                "timestamp": a_ts + timedelta(seconds=30),
+            }
+        ]
+        coverage = {
+            "covered_since": a_ts - timedelta(minutes=10),
+            "covered_until": base,
+            "scan_complete": True,
+        }
+
+        reconcile_issuances(self.conn, chain, **coverage)
+
+        rows = self.x(
+            "SELECT id, status FROM token_issuance_log WHERE id IN (%s, %s) ORDER BY id",
+            (a_id, b_id),
+        ).fetchall()
+        self.assertEqual(rows[0][1], "SUCCESS")
+        self.assertEqual(rows[1][1], "PENDING")  # contested, not FAILURE
+
+        reconcile_issuances(self.conn, chain, **coverage)
+
+        b_status = self.x(
+            "SELECT status FROM token_issuance_log WHERE id = %s", (b_id,)
+        ).fetchone()[0]
+        self.assertEqual(b_status, "FAILURE")
 
 
 if __name__ == "__main__":

--- a/tests/test_virtual_tokens.py
+++ b/tests/test_virtual_tokens.py
@@ -41,6 +41,7 @@ from hsbi_token_snapshot import (
     log_issuance,
     reconcile_issuances,
     sync_tokenholders,
+    warn_stuck_pending,
 )
 
 # --- sentinel names so DB tests never collide with real members ---------------
@@ -221,6 +222,26 @@ class PureLogicTests(unittest.TestCase):
             scan["covered_since"], datetime.min.replace(tzinfo=timezone.utc)
         )
         self.assertIsNotNone(scan["covered_until"])
+
+    def test_scan_incomplete_when_history_exceeds_limit(self):
+        # The failure HISTORY_SCAN_LIMIT guards against: a burst longer than the
+        # budget stops the walk before the cutoff, so absence is never proven, no
+        # PENDING row can be failed, and issue_balance_tokens skips those members
+        # every cycle. In the high-VP regime (cycle every ~15 min) a single window
+        # has held ~1600 issuances, which is why the limit is sized well above it.
+        recent = datetime.now(timezone.utc) - timedelta(minutes=1)
+        rows = [
+            {"trx_id": f"op_{i}", "timestamp": recent, "op": ["custom_json", {}]}
+            for i in range(5)
+        ]
+        truncated = fetch_recent_chain_issuance_scan(FakeChainIssuer(rows), limit=3)
+        self.assertFalse(truncated["complete"])
+        self.assertIsNone(truncated["covered_since"])
+
+        # Same history, budget above the burst: coverage is proven.
+        sufficient = fetch_recent_chain_issuance_scan(FakeChainIssuer(rows), limit=10)
+        self.assertTrue(sufficient["complete"])
+        self.assertIsNotNone(sufficient["covered_since"])
 
 
 @unittest.skipUnless(_DB_ENGINE is not None, _DB_SKIP_REASON)
@@ -724,6 +745,197 @@ class ReconciliationTests(DBTestCase):
             "SELECT COUNT(*) FROM token_issuance_log WHERE rationale = 'reconciled'"
         ).fetchone()[0]
         self.assertEqual(int(reconciled), 0)
+
+    def test_uncaptured_success_claims_chain_issue_before_pending_row(self):
+        # A SUCCESS row logged 'N/A' and a PENDING row share recipient and units,
+        # and both are in-window for the single chain issue. The chain issue belongs
+        # to the SUCCESS row (it is already on chain); handing it to the PENDING row
+        # would stamp that row with another issuance's trx_id and strand the 'N/A'
+        # row on its placeholder forever.
+        now = datetime.now(timezone.utc)
+        uncaptured = log_issuance(
+            self.conn,
+            "N/A",
+            T_PIK,
+            Decimal("4.000"),
+            "SUCCESS",
+            "pik",
+            issued_at=now - timedelta(minutes=10),
+        )
+        uncaptured_id = self.x(
+            "SELECT id FROM token_issuance_log WHERE trx_id = 'N/A' "
+            "AND recipient = %s AND units = %s",
+            (T_PIK, Decimal("4.000")),
+        ).fetchone()[0]
+        pending_id = insert_pending_issuance(
+            self.conn,
+            T_PIK,
+            Decimal("4.000"),
+            "Pending Balance Conversion",
+            issued_at=now - timedelta(minutes=9),
+        )
+        chain = [
+            {
+                "trx_id": "chain_uncaptured_wins",
+                "recipient": T_PIK,
+                "units": Decimal("4.000"),
+                "timestamp": now - timedelta(minutes=8),
+            }
+        ]
+        reconcile_issuances(self.conn, chain)
+
+        self.assertEqual(
+            self.x(
+                "SELECT trx_id FROM token_issuance_log WHERE id = %s", (uncaptured_id,)
+            ).fetchone()[0],
+            "chain_uncaptured_wins",
+        )
+        # The PENDING row must not have absorbed the same chain issue.
+        pending_row = self.x(
+            "SELECT status, trx_id FROM token_issuance_log WHERE id = %s", (pending_id,)
+        ).fetchone()
+        self.assertEqual(pending_row[0], "PENDING")
+        self.assertEqual(pending_row[1], "PENDING")
+        # And no chain issue may ever be re-logged as a new row.
+        self.assertEqual(
+            int(
+                self.x(
+                    "SELECT COUNT(*) FROM token_issuance_log WHERE trx_id = %s",
+                    ("chain_uncaptured_wins",),
+                ).fetchone()[0]
+            ),
+            1,
+        )
+
+    def test_uncaptured_pass_leaves_pending_its_own_chain_issue(self):
+        # Mirror of the test above, and the regression guard for the reorder: with
+        # 'N/A' completion running first it must consume only the issue that is
+        # closest to its own row, never sweep the pool. Both rows share recipient
+        # and units and BOTH chain issues fall inside BOTH match windows, so the
+        # separation comes from ordering + proximity, not from disjoint windows.
+        base = datetime.now(timezone.utc) - timedelta(minutes=20)
+        log_issuance(
+            self.conn,
+            "N/A",
+            T_PIK,
+            Decimal("7.000"),
+            "SUCCESS",
+            "pik",
+            issued_at=base,
+        )
+        uncaptured_id = self.x(
+            "SELECT id FROM token_issuance_log WHERE trx_id = 'N/A' "
+            "AND recipient = %s AND units = %s",
+            (T_PIK, Decimal("7.000")),
+        ).fetchone()[0]
+        pending_id = insert_pending_issuance(
+            self.conn,
+            T_PIK,
+            Decimal("7.000"),
+            "Pending Balance Conversion",
+            issued_at=base + timedelta(minutes=3),
+        )
+        chain = [
+            {
+                "trx_id": "chain_for_uncaptured",
+                "recipient": T_PIK,
+                "units": Decimal("7.000"),
+                "timestamp": base + timedelta(minutes=1),
+            },
+            {
+                "trx_id": "chain_for_pending",
+                "recipient": T_PIK,
+                "units": Decimal("7.000"),
+                "timestamp": base + timedelta(minutes=4),
+            },
+        ]
+        reconcile_issuances(self.conn, chain)
+
+        self.assertEqual(
+            self.x(
+                "SELECT trx_id FROM token_issuance_log WHERE id = %s", (uncaptured_id,)
+            ).fetchone()[0],
+            "chain_for_uncaptured",
+        )
+        pending_row = self.x(
+            "SELECT status, trx_id FROM token_issuance_log WHERE id = %s", (pending_id,)
+        ).fetchone()
+        self.assertEqual(pending_row[0], "SUCCESS")
+        self.assertEqual(pending_row[1], "chain_for_pending")
+        # Two issuances in, two rows out — neither chain op created a third.
+        self.assertEqual(
+            int(
+                self.x(
+                    "SELECT COUNT(*) FROM token_issuance_log "
+                    "WHERE recipient = %s AND units = %s",
+                    (T_PIK, Decimal("7.000")),
+                ).fetchone()[0]
+            ),
+            2,
+        )
+
+    def test_second_chain_issue_cannot_complete_the_same_row_twice(self):
+        # Two in-window chain issues, one uncaptured row. The first completes it;
+        # the second must fall through to the recognise-and-report branch, never
+        # inserting a row. This is the invariant PR #138 violated.
+        base = datetime.now(timezone.utc) - timedelta(minutes=20)
+        log_issuance(
+            self.conn,
+            "N/A",
+            T_PIK,
+            Decimal("8.000"),
+            "SUCCESS",
+            "pik",
+            issued_at=base,
+        )
+        chain = [
+            {
+                "trx_id": "chain_first",
+                "recipient": T_PIK,
+                "units": Decimal("8.000"),
+                "timestamp": base + timedelta(minutes=1),
+            },
+            {
+                "trx_id": "chain_second",
+                "recipient": T_PIK,
+                "units": Decimal("8.000"),
+                "timestamp": base + timedelta(minutes=2),
+            },
+        ]
+        reconcile_issuances(self.conn, chain)
+
+        rows = self.x(
+            "SELECT trx_id FROM token_issuance_log "
+            "WHERE recipient = %s AND units = %s",
+            (T_PIK, Decimal("8.000")),
+        ).fetchall()
+        self.assertEqual([r[0] for r in rows], ["chain_first"])
+
+    def test_warn_stuck_pending_flags_only_old_pending_rows(self):
+        # A stuck PENDING row blocks its (recipient, rationale) in
+        # issue_balance_tokens and produces no error of its own, so the alert is
+        # the only signal that a member has stopped being paid.
+        now = datetime.now(timezone.utc)
+        baseline = warn_stuck_pending(self.conn)
+
+        insert_pending_issuance(
+            self.conn, T_PIK, Decimal("1.000"), "pik", issued_at=now - timedelta(hours=7)
+        )
+        insert_pending_issuance(
+            self.conn, T_GUARD, Decimal("1.000"), "pik", issued_at=now - timedelta(hours=1)
+        )
+        log_issuance(
+            self.conn,
+            "chain_old_success",
+            T_HOLDER,
+            Decimal("1.000"),
+            "SUCCESS",
+            "pik",
+            issued_at=now - timedelta(hours=7),
+        )
+
+        # Only the old PENDING row qualifies: recent PENDING and old SUCCESS do not.
+        self.assertEqual(warn_stuck_pending(self.conn) - baseline, 1)
 
     def test_stale_unmatched_pending_stays_pending_without_covered_scan(self):
         stale_ts = datetime.now(timezone.utc) - timedelta(hours=6)


### PR DESCRIPTION
## Summary

- Make token issuance paths use committed `PENDING` intent rows before broadcast, then update the same row to `SUCCESS` with the actual Hive Engine issue transaction id.
- Split Unit Conversion origin transactions from issue transactions with `source_trx_id`, so the HBD transfer hash is no longer treated as the issuance `trx_id`.
- Refactor reconciliation to use blockchain transaction timestamps, complete/fail/report existing rows only, and never insert `rationale='reconciled'` rows.
- Refresh `josephsavage.virtual_tokens` as 10% of all non-management virtual tokens during delegation checks.
- Add schema/runbook/docs updates plus regression coverage for source-vs-issue trx ids, timestamp matching, stale scan coverage, orphan reporting, and Management virtual tokens.

## Root Cause

Reconciliation was able to treat an on-chain issue as a new durable issuance record, including inventing `rationale='reconciled'`. Unit Conversion also mixed the source HBD transfer transaction id with the actual Hive Engine issue transaction id, which made later chain reconciliation see the real issue hash as new information instead of the completion of an existing issuance.

## Validation

- `python3 -m py_compile hsbi_token_snapshot.py hsbi_check_delegation.py hivesbi/parse_hist_op.py tests/test_virtual_tokens.py`
- `git diff --check -- CHANGES.md docker/mariadb/init/01-sbi-schema.sql hivesbi/parse_hist_op.py hsbi_check_delegation.py hsbi_token_snapshot.py sql/20260602_virtual_tokens.sql sql/PROD_RUNBOOK_virtual_tokens.sql tests/test_virtual_tokens.py`
- `python3 -m unittest tests.test_virtual_tokens` could not run in this local shell because `dataset` is not installed (`ModuleNotFoundError: No module named 'dataset'`).